### PR TITLE
Fix Issue #7: fp.to_dataframe is slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The visualisation notebook now displays the protein with py3Dmol. Some examples for
   creating and displaying a graph from the interaction dataframe have been added
 - Updated the installation instructions to show how to install a specific release
+- The previous repr method of `ResidueId` was easy to confuse with a string, especially
+  when trying to access the `Fingerprint.ifp` results by string. The new repr method is
+  now more explicit.
 ### Deprecated
 ### Removed
 ### Fixed
+- `Fingerprint.to_dataframe` is now much faster (Issue #7)
 
 ## [0.3.0] - 2020-12-23
 ### Added

--- a/prolif/residue.py
+++ b/prolif/residue.py
@@ -36,6 +36,9 @@ class ResidueId:
             self.resid += f".{self.chain}"
 
     def __repr__(self):
+        return f"ResidueId({self.name}, {self.number}, {self.chain})"
+
+    def __str__(self):
         return self.resid
 
     def __hash__(self):

--- a/tests/test_residues.py
+++ b/tests/test_residues.py
@@ -115,6 +115,17 @@ class TestResidueId:
         res2 = ResidueId.from_string(res2)
         assert res1 < res2
 
+    @pytest.mark.parametrize("resid_str", [
+        "ALA1.A",
+        "DA2.B",
+        "HIS3",
+        "GLU",
+    ])
+    def test_repr(self, resid_str):
+        resid = ResidueId.from_string(resid_str)
+        expected = f"ResidueId({resid.name}, {resid.number}, {resid.chain})"
+        assert repr(resid) == expected
+
 
 class TestResidue(TestBaseRDKitMol):
     @pytest.fixture(scope="class")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,13 +133,13 @@ def test_to_df_atom_pairs():
     assert df.shape == (2, 4)
     assert df.index.name == "Frame"
     assert ("LIG", "ALA1", "A") in df.columns
-    assert df[("LIG", "ALA1", "A")][0] == [0, 1]
+    assert df[("LIG", "ALA1", "A")][0] == (0, 1)
     assert ("LIG", "ALA1", "B") in df.columns
-    assert df[("LIG", "ALA1", "B")][0] == [None, None]
+    assert df[("LIG", "ALA1", "B")][0] == (None, None)
     assert ("LIG", "ALA1", "C") not in df.columns
     assert ("LIG", "GLU2", "A") not in df.columns
     assert ("LIG", "ASP3", "B") in df.columns
-    assert df[("LIG", "ASP3", "B")][0] == [None, None]
+    assert df[("LIG", "ASP3", "B")][0] == (None, None)
 
 
 @pytest.mark.parametrize("dtype", [


### PR DESCRIPTION
Fixes issue #7 

- Updated the repr method of `ResidueId` so that it isn't confused with a string anymore
- Improved the speed of the `to_dataframe` function, from 8.5s to 150ms (TM3-GPCR PPI example)