### PR TITLE
Issue #8: Better support for DNA residues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- `ResidueId.from_string` method now supports 1-letter and 2-letter codes for RNA/DNA
+  (Issue #8)
 
 ## [0.3.0] - 2020-12-23
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ ProLIF
 Description
 -----------
 
-ProLIF (*Protein-Ligand Interaction Fingerprints*) is a tool designed to generate interaction fingerprints for protein-ligand and protein-protein interactions extracted from molecular dynamics trajectories and docking simulations.
+ProLIF (*Protein-Ligand Interaction Fingerprints*) is a tool designed to generate interaction fingerprints for protein-ligand and protein-protein interactions extracted from molecular dynamics trajectories and docking simulations. It also supports DNA-ligand, DNA-protein and DNA-DNA interactions.
 
 You can try it out prior to any installation on `Binder <https://mybinder.org/v2/gh/chemosim-lab/ProLIF/HEAD?filepath=docs%2Fnotebooks>`_.
 

--- a/prolif/residue.py
+++ b/prolif/residue.py
@@ -9,7 +9,7 @@ import numpy as np
 from .rdkitmol import BaseRDKitMol
 
 
-_RE_RESID = re.compile(r'([A-Z]{3})?(\d*)\.?(\w)?')
+_RE_RESID = re.compile(r'([A-Z]{,3})?(\d*)\.?(\w)?')
 
 
 class ResidueId:

--- a/tests/test_residues.py
+++ b/tests/test_residues.py
@@ -38,6 +38,7 @@ class TestResidueId:
         ("ALA", 1, None),
         ("ALA", None, "B"),
         ("ALA", 1, "B"),
+        ("DA", 1, None),
         (None, 1, "B"),
         (None, None, "B"),
         (None, 1, None),
@@ -93,6 +94,9 @@ class TestResidueId:
         (".0", (None, None, "0")),
         ("1", (None, 1, None)),
         ("", (None, None, None)),
+        ("DA2.A", ("DA", 2, "A")),
+        ("DA2", ("DA", 2, None)),
+        ("DA", ("DA", None, None)),
     ])
     def test_string_methods(self, resid_str, expected):
         resid = ResidueId.from_string(resid_str)


### PR DESCRIPTION
Fixes issue #8 

- Fixes the `ResidueId.from_string` regex to support residues codes of 1 to 3 letters (RNA, DNA and proteins)