### PR TITLE
Fix issue #13: residues with resnumber=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- Default residue name and number: `UNK` and `0` are now the default values if `None` or
+  `''` is given
 ### Deprecated
 ### Removed
 ### Fixed
+- Residues with a resnumber of `0` are not converted to `None` anymore (Issue #13)
 
 ## [0.3.1] - 2021-02-02
 ### Added

--- a/prolif/residue.py
+++ b/prolif/residue.py
@@ -10,6 +10,7 @@ from .rdkitmol import BaseRDKitMol
 
 
 _RE_RESID = re.compile(r'([A-Z]{,3})?(\d*)\.?(\w)?')
+NoneType = type(None)
 
 
 class ResidueId:
@@ -17,29 +18,29 @@ class ResidueId:
     
     Parameters
     ----------
-    name : str or None, optionnal
+    name : str
         3-letter residue name
-    number : int or None, optionnal
+    number : int
         residue number
     chain : str or None, optionnal
         1-letter protein chain
     """
     def __init__(self,
-                 name: Optional[str] = None,
-                 number: Optional[int] = None,
+                 name: str = "UNK",
+                 number: int = 0,
                  chain: Optional[str] = None):
-        self.name = name or None
-        self.number = number or None
+        self.name = name or "UNK"
+        self.number = number or 0
         self.chain = chain or None
-        self.resid = f"{self.name or ''}{self.number or ''}"
-        if self.chain:
-            self.resid += f".{self.chain}"
 
     def __repr__(self):
         return f"ResidueId({self.name}, {self.number}, {self.chain})"
 
     def __str__(self):
-        return self.resid
+        resid = f"{self.name}{self.number}"
+        if self.chain:
+            resid += f".{self.chain}"
+        return resid
 
     def __hash__(self):
         return hash((self.name, self.number, self.chain))
@@ -88,23 +89,23 @@ class ResidueId:
         +-----------+----------------------------------+
         | "GLU33"   | ``ResidueId("GLU", 33, None)``   |
         +-----------+----------------------------------+
-        | "LYS.B"   | ``ResidueId("LYS", None, "B")``  |
+        | "LYS.B"   | ``ResidueId("LYS", 0, "B")``     |
         +-----------+----------------------------------+
-        | "ARG"     | ``ResidueId("ARG", None, None)`` |
+        | "ARG"     | ``ResidueId("ARG", 0, None)``    |
         +-----------+----------------------------------+
-        | "5.C"     | ``ResidueId(None, 5, "C")``      |
+        | "5.C"     | ``ResidueId("UNK", 5, "C")``     |
         +-----------+----------------------------------+
-        | "42"      | ``ResidueId(None, 42, None)``    |
+        | "42"      | ``ResidueId("UNK", 42, None)``   |
         +-----------+----------------------------------+
-        | ".D"      | ``ResidueId(None, None, "D")``   |
+        | ".D"      | ``ResidueId("UNK", 0, "D")``     |
         +-----------+----------------------------------+
-        | ""        | ``ResidueId(None, None, None)``  |
+        | ""        | ``ResidueId("UNK", 0, None)``    |
         +-----------+----------------------------------+
 
         """
         matches = _RE_RESID.search(resid_str)
         name, number, chain = matches.groups()
-        number = int(number) if number else None
+        number = int(number) if number else 0
         return cls(name, number, chain)
 
 

--- a/tests/test_residues.py
+++ b/tests/test_residues.py
@@ -10,32 +10,30 @@ class TestResidueId:
     @pytest.mark.parametrize("name, number, chain", [
         ("ALA", None, None),
         ("ALA", 1, None),
+        ("ALA", 0, None),
         ("ALA", None, "B"),
         ("ALA", 1, "B"),
         (None, 1, "B"),
         (None, None, "B"),
         (None, 1, None),
         (None, None, None),
+        ("", None, None),
+        (None, None, ""),
+        ("", None, ""),
     ])
     def test_init(self, name, number, chain):
         resid = ResidueId(name, number, chain)
+        name = name or "UNK"
+        number = number or 0
+        chain = chain or None
         assert resid.name == name
         assert resid.number == number
         assert resid.chain == chain
-    
-    @pytest.mark.parametrize("name, number, chain", [
-        ("", None, None),
-        (None, 0, None),
-        (None, None, ""),
-        (None, None, None),
-    ])
-    def test_init_empty(self, name, number, chain):
-        resid = ResidueId(name, number, chain)
-        assert resid == ResidueId()
 
     @pytest.mark.parametrize("name, number, chain", [
         ("ALA", None, None),
         ("ALA", 1, None),
+        ("ALA", 0, None),
         ("ALA", None, "B"),
         ("ALA", 1, "B"),
         ("DA", 1, None),
@@ -43,28 +41,11 @@ class TestResidueId:
         (None, None, "B"),
         (None, 1, None),
         (None, None, None),
+        ("", None, None),
+        (None, None, ""),
+        ("", None, ""),
     ])
     def test_from_atom(self, name, number, chain):
-        atom = Chem.Atom(1)
-        mi = Chem.AtomPDBResidueInfo()
-        if name:
-            mi.SetResidueName(name)
-        if number:
-            mi.SetResidueNumber(number)
-        if chain:
-            mi.SetChainId(chain)
-        atom.SetMonomerInfo(mi)
-        resid = ResidueId.from_atom(atom)
-        assert resid.name == name
-        assert resid.number == number
-        assert resid.chain == chain
-
-    @pytest.mark.parametrize("name, number, chain", [
-        ("", None, None),
-        (None, 0, None),
-        (None, None, ""),
-    ])
-    def test_from_atom_empty(self, name, number, chain):
         atom = Chem.Atom(1)
         mi = Chem.AtomPDBResidueInfo()
         if name is not None:
@@ -75,33 +56,37 @@ class TestResidueId:
             mi.SetChainId(chain)
         atom.SetMonomerInfo(mi)
         resid = ResidueId.from_atom(atom)
-        assert resid == ResidueId()
+        name = name or "UNK"
+        number = number or 0
+        chain = chain or None
+        assert resid.name == name
+        assert resid.number == number
+        assert resid.chain == chain
 
     def test_from_atom_no_mi(self):
         atom = Chem.Atom(1)
         resid = ResidueId.from_atom(atom)
-        assert resid.name is None
-        assert resid.number is None
+        assert resid.name is "UNK"
+        assert resid.number is 0
         assert resid.chain is None
 
     @pytest.mark.parametrize("resid_str, expected", [
-        ("ALA", ("ALA", None, None)),
+        ("ALA", ("ALA", 0, None)),
         ("ALA1", ("ALA", 1, None)),
-        ("ALA.B", ("ALA", None, "B")),
+        ("ALA.B", ("ALA", 0, "B")),
         ("ALA1.B", ("ALA", 1, "B")),
-        ("1.B", (None, 1, "B")),
-        (".B", (None, None, "B")),
-        (".0", (None, None, "0")),
-        ("1", (None, 1, None)),
-        ("", (None, None, None)),
+        ("1.B", ("UNK", 1, "B")),
+        (".B", ("UNK", 0, "B")),
+        (".0", ("UNK", 0, "0")),
+        ("1", ("UNK", 1, None)),
+        ("", ("UNK", 0, None)),
         ("DA2.A", ("DA", 2, "A")),
         ("DA2", ("DA", 2, None)),
-        ("DA", ("DA", None, None)),
+        ("DA", ("DA", 0, None)),
     ])
-    def test_string_methods(self, resid_str, expected):
+    def test_from_string(self, resid_str, expected):
         resid = ResidueId.from_string(resid_str)
         assert resid == ResidueId(*expected)
-        assert str(resid) == resid_str
 
     def test_eq(self):
         name, number, chain = "ALA", 1, "A"
@@ -123,12 +108,13 @@ class TestResidueId:
         "ALA1.A",
         "DA2.B",
         "HIS3",
-        "GLU",
+        "UNK0"
     ])
     def test_repr(self, resid_str):
         resid = ResidueId.from_string(resid_str)
         expected = f"ResidueId({resid.name}, {resid.number}, {resid.chain})"
         assert repr(resid) == expected
+        assert str(resid) == resid_str
 
 
 class TestResidue(TestBaseRDKitMol):


### PR DESCRIPTION
Fixes issue #13 

Changed:
* Default residue name and number: `UNK` and `0` are now the default values if `None` or `''` is given

Fixed:
* Residues with a resnumber of `0` are not converted to `None` anymore