### PR TITLE
Preparation for v0.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ defaults:
   run:
     shell: bash -l {0}
 
+concurrency:
+  group: "${{ github.repository }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: CI on ${{ matrix.os }} with Python ${{ matrix.python-version }}
@@ -25,6 +29,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: GitHub Actions
+      run: |
+        echo "${{ github.repository }}-${{ github.ref }}"
 
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   tests:
-    name: CI on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    name: CI - ${{ matrix.os }} / Py${{ matrix.python-version }} / {{ matrix.rdkit-version }}
     runs-on: ${{ matrix.os }}
     # only run once if internal PR
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: GitHub Actions
-      run: |
-        echo "${{ github.ref }}-${{ github.head_ref }}"
-
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,14 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
         matrix:
-          os: [ubuntu-18.04]
+          os: [ubuntu-latest]
           python-version: [3.6, 3.8, 3.9]
+          rdkit-version: ["rdkit>=2020.09.1"]
+          include:
+          - name: RDKit min version
+            os: ubuntu-latest
+            python-version: 3.6
+            rdkit-version: "rdkit==2020.03.1"
 
     steps:
     - uses: actions/checkout@v2
@@ -50,7 +56,7 @@ jobs:
     - name: Install conda dependencies
       run: |
         conda install mamba
-        mamba install rdkit cython wheel
+        mamba install ${{ matrix.rdkit-version }} cython wheel
         conda list
 
     - name: Install package through pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         import prolif
         import os
         print(prolif.__version__)
+        from prolif.plotting.network import LigNetwork
         assert os.path.isfile(prolif.datafiles.TOP)
         EOF
 
@@ -104,5 +105,6 @@ jobs:
         import prolif
         import os
         print(prolif.__version__)
+        from prolif.plotting.network import LigNetwork
         assert os.path.isfile(prolif.datafiles.TOP)
         EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash -l {0}
 
 concurrency:
-  group: "${{ github.repository }}-${{ github.ref }}"
+  group: "${{ github.ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
 
     - name: GitHub Actions
       run: |
-        echo "${{ github.repository }}-${{ github.ref }}"
+        echo "${{ github.ref }}-${{ github.head_ref }}"
 
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   tests:
-    name: CI - ${{ matrix.os }} / Py${{ matrix.python-version }} / {{ matrix.rdkit-version }}
+    name: CI - ${{ matrix.os }} / Py${{ matrix.python-version }} / ${{ matrix.rdkit-version }}
     runs-on: ${{ matrix.os }}
     # only run once if internal PR
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,6 @@
+scanner:
+  diff_only: False
+  linter: pycodestyle  # Alternative option - flake8
+
+pycodestyle:
+  max-line-length: 79

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,6 +1,10 @@
 scanner:
-  diff_only: False
+  diff_only: True
   linter: pycodestyle  # Alternative option - flake8
 
 pycodestyle:
   max-line-length: 79
+  exclude:
+    - docs/conf.py
+    - prolif/_version.py
+    - versioneer.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- LigNetwork: an interaction diagram with atomistic details for the ligand and
+  residue-level details for the protein, fully interactive in a browser/notebook, inspired
+  from LigPlot (PR #19)
+- `fp.generate`: a method to get the IFP between two `prolif.Molecule` objects (PR #19)
 ### Changed
 - Default residue name and number: `UNK` and `0` are now the default values if `None` or
   `''` is given
+- The Hydrophobic interaction now uses `+0` (no charge) instead of `!$([+{1-},-{1-}])`
+  (not negatively or positively charged) for part of its SMARTS pattern (PR #19)
+- Moved the `return_atoms` parameter from the `run` methods to `to_dataframe` to avoid
+  recalculating the IFP if one wants to display it with atomic details (PR #19)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (not negatively or positively charged) for part of its SMARTS pattern (PR #19)
 - Moved the `return_atoms` parameter from the `run` methods to `to_dataframe` to avoid
   recalculating the IFP if one wants to display it with atomic details (PR #19)
+- Changed the values returned by `fp.bitvector_atoms`: the atom indices have been
+  separated in two lists, one for the ligand and one for the protein (PR #19)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,10 @@ ProLIF
 Description
 -----------
 
-ProLIF (*Protein-Ligand Interaction Fingerprints*) is a tool designed to generate interaction fingerprints for protein-ligand and protein-protein interactions extracted from molecular dynamics trajectories and docking simulations. It also supports DNA-ligand, DNA-protein and DNA-DNA interactions.
+ProLIF (*Protein-Ligand Interaction Fingerprints*) is a tool designed to generate
+interaction fingerprints for complexes made of ligands, protein, DNA or RNA molecules
+extracted from molecular dynamics trajectories, docking simulations and experimental
+structures.
 
 You can try it out prior to any installation on `Binder <https://mybinder.org/v2/gh/chemosim-lab/ProLIF/HEAD?filepath=docs%2Fnotebooks>`_.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ from jupyter_client import kernelspec
 # -- Project information -----------------------------------------------------
 
 project = 'ProLIF'
-copyright = '2020, Cédric Bouysset'
+copyright = '2020-2021, Cédric Bouysset'
 author = 'Cédric Bouysset'
 
 

--- a/docs/notebooks/how-to.ipynb
+++ b/docs/notebooks/how-to.ipynb
@@ -276,7 +276,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, the fingerprint will modify all interaction classes to only return the boolean value. To get the atom indices when using your custom class, you must choose one of the following options:"
+    "By default, the fingerprint will modify all interaction classes to only return the boolean value. To get the atom indices you must choose one of the following options:"
+   ]
+  },
+  {
+   "source": [
+    "* Call `fp.to_dataframe(return_atoms=True)`"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fp.to_dataframe(return_atoms=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Use the `return_atoms=True` argument when calling the `generate` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ifp = fp.generate(lmol, pmol, return_atoms=True)\n",
+    "ifp"
    ]
   },
   {
@@ -309,25 +342,8 @@
    "outputs": [],
    "source": [
     "fp = plf.Fingerprint([\"CloseContact\"])\n",
-    "bv, indices = fp.bitvector_atoms(lmol, pmol[\"ASP129.A\"])\n",
-    "bv, indices"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "* Use the `return_atoms=True` argument when calling the `run` method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fp.run(u.trajectory[0:1], lig, prot, return_atoms=True)\n",
-    "fp.ifp"
+    "bv, lig_ix, prot_ix = fp.bitvector_atoms(lmol, pmol[\"ASP129.A\"])\n",
+    "bv, lig_ix, prot_ix"
    ]
   },
   {
@@ -545,9 +561,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python385jvsc74a57bd0ed16e0ce086f53f6a3b96f2d7e8fdc3cba2fa42f4f858ca7715a8f0f47550c6a",
+   "display_name": "Python 3.8.5 64-bit ('prolif': conda)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -559,7 +574,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5-final"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/how-to.ipynb
+++ b/docs/notebooks/how-to.ipynb
@@ -287,15 +287,6 @@
    "metadata": {}
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fp.to_dataframe(return_atoms=True)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/notebooks/how-to.ipynb
+++ b/docs/notebooks/how-to.ipynb
@@ -300,7 +300,9 @@
    "outputs": [],
    "source": [
     "ifp = fp.generate(lmol, pmol, return_atoms=True)\n",
-    "ifp"
+    "# check the interactino between the ligand and ASP129\n",
+    "ifp[(plf.ResidueId(\"LIG\", 1, \"G\"),\n",
+    "     plf.ResidueId(\"ASP\", 129, \"A\"))]"
    ]
   },
   {

--- a/docs/notebooks/protein-protein_interactions.ipynb
+++ b/docs/notebooks/protein-protein_interactions.ipynb
@@ -126,9 +126,8 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3.8.5 64-bit ('prolif': conda)",
-   "language": "python",
-   "name": "python38564bitprolifconda6f88be71e4394ccb9ad64335b88224ec"
+   "name": "python385jvsc74a57bd0ed16e0ce086f53f6a3b96f2d7e8fdc3cba2fa42f4f858ca7715a8f0f47550c6a",
+   "display_name": "Python 3.8.5 64-bit ('prolif': conda)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -140,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5-final"
+   "version": "3.8.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/notebooks/visualisation.ipynb
+++ b/docs/notebooks/visualisation.ipynb
@@ -204,6 +204,7 @@
     "Protein-ligand interactions are typically represented with the ligand in atomic details, residues as nodes, and interactions as edges. Such diagram can be easily displayed by calling ProLIF's builtin class `prolif.plotting.network.LigNetwork`.\n",
     "This diagram is interactive and allows moving around the residues, as well as clicking the legend to toggle the display of specific residues types or interactions.\n",
     "LigNetwork can generate two kinds of depictions:\n",
+    "\n",
     "- Based on a single specific frame\n",
     "- By aggregating results from several frames\n",
     "\n",

--- a/docs/notebooks/visualisation.ipynb
+++ b/docs/notebooks/visualisation.ipynb
@@ -199,9 +199,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## RDKit\n",
+    "## Ligand Interaction Network (LigPlot)\n",
     "\n",
-    "This script is given as a starting point for visualising the interactions with RDKit. It's definitely not ideal for 3D visualisation as the drawing ends up being crowded and quite unreadable very quickly. I'm sure there's a better way to do this but it will do as a code snippet."
+    "Protein-ligand interactions are typically represented with the ligand in atomic details, residues as nodes, and interactions as edges. Such diagram can be easily displayed by calling ProLIF's builtin class `prolif.plotting.network.LigNetwork`.\n",
+    "This diagram is interactive and allows moving around the residues, as well as clicking the legend to toggle the display of specific residues types or interactions.\n",
+    "LigNetwork can generate two kinds of depictions:\n",
+    "- Based on a single specific frame\n",
+    "- By aggregating results from several frames\n",
+    "\n",
+    "In the latter case, the frequency with which an interaction is seen will control the width of the corresponding edge. You can hide the least frequent interactions by using a threshold, *i.e.* `threshold=0.3` will hide interactions that occur in less than 30% of frames."
    ]
   },
   {
@@ -210,47 +216,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rdkit.Chem import Draw\n",
-    "from IPython import display\n",
+    "from prolif.plotting.network import LigNetwork\n",
     "\n",
-    "colors = {\n",
-    "    \"HBAcceptor\": (0, 1, 1),\n",
-    "    \"HBDonor\": (1, .7,.3),\n",
-    "    \"Cationic\": (0, 1, 0),\n",
-    "    \"PiStacking\": (.5, 0, .5),\n",
-    "}\n",
+    "fp = plf.Fingerprint()\n",
+    "fp.run(u.trajectory[::10], lig, prot)\n",
+    "df = fp.to_dataframe(return_atoms=True)\n",
     "\n",
-    "d = Draw.MolDraw2DSVG(650, 600)\n",
-    "opts = Draw.MolDrawOptions()\n",
-    "opts.fixedBondLength = 25\n",
-    "d.SetDrawOptions(opts)\n",
-    "\n",
-    "displayed = []\n",
-    "for i, row in df.T.iterrows():\n",
-    "    lresid, presid, interaction = i\n",
-    "    lindex, pindex = row[0]\n",
-    "    lres = lmol[lresid]\n",
-    "    pres = pmol[presid]\n",
-    "    for resid, res in [(lresid, lres), (presid, pres)]:\n",
-    "        if resid not in displayed:\n",
-    "            displayed.append(resid)\n",
-    "            d.DrawMolecule(res)\n",
-    "    if interaction in [\"PiStacking\", \"EdgeToFace\", \"FaceToFace\", \"PiCation\"]:\n",
-    "        p1 = get_ring_centroid(lres, lindex)\n",
-    "    else:\n",
-    "        p1 = lres.GetConformer().GetAtomPosition(lindex)\n",
-    "    if interaction in [\"PiStacking\", \"EdgeToFace\", \"FaceToFace\", \"CationPi\"]:\n",
-    "        p2 = get_ring_centroid(pres, pindex)\n",
-    "    else:\n",
-    "        p2 = pres.GetConformer().GetAtomPosition(pindex)\n",
-    "    p1 = Geometry.Point2D(p1)\n",
-    "    p2 = Geometry.Point2D(p2)\n",
-    "    d.DrawWavyLine(p1, p2, colors[interaction], colors[interaction])\n",
-    "    \n",
-    "# display\n",
-    "d.FinishDrawing()\n",
-    "display.SVG(d.GetDrawingText())"
+    "net = LigNetwork.from_ifp(df, lmol,\n",
+    "                          # replace with `kind=\"frame\", frame=0` for the other depiction\n",
+    "                          kind=\"aggregate\", threshold=.3,\n",
+    "                          rotation=270)\n",
+    "net.display()"
    ]
+  },
+  {
+   "source": [
+    "You can further customize the diagram by changing the colors in LigNetwork.COLORS or the residues types in LigNetwork.RESIDUE_TYPES. Type `help(LigNetwork)` for more details."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -572,9 +556,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.5 64-bit ('prolif': conda)",
-   "language": "python",
-   "name": "python38564bitprolifconda6f88be71e4394ccb9ad64335b88224ec"
+   "name": "python385jvsc74a57bd0ed16e0ce086f53f6a3b96f2d7e8fdc3cba2fa42f4f858ca7715a8f0f47550c6a",
+   "display_name": "Python 3.8.5 64-bit ('prolif': conda)"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/notebooks/visualisation.ipynb
+++ b/docs/notebooks/visualisation.ipynb
@@ -43,8 +43,8 @@
    "source": [
     "# get lig-prot interactions with atom info\n",
     "fp = plf.Fingerprint([\"HBDonor\", \"HBAcceptor\", \"Cationic\", \"PiStacking\"])\n",
-    "fp.run(u.trajectory[0:1], lig, prot, return_atoms=True)\n",
-    "df = fp.to_dataframe()\n",
+    "fp.run(u.trajectory[0:1], lig, prot)\n",
+    "df = fp.to_dataframe(return_atoms=True)\n",
     "df.T"
    ]
   },

--- a/docs/notebooks/visualisation.ipynb
+++ b/docs/notebooks/visualisation.ipynb
@@ -231,7 +231,7 @@
   },
   {
    "source": [
-    "You can further customize the diagram by changing the colors in LigNetwork.COLORS or the residues types in LigNetwork.RESIDUE_TYPES. Type `help(LigNetwork)` for more details."
+    "You can further customize the diagram by changing the colors in `LigNetwork.COLORS` or the residues types in `LigNetwork.RESIDUE_TYPES`. Type `help(LigNetwork)` for more details."
    ],
    "cell_type": "markdown",
    "metadata": {}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -33,3 +33,5 @@ Helper functions
 ProLIF comes with a set of functions that should help users analyse the results
 produced by the package more easily. The documentation for these functions can
 be found in the :ref:`source/modules/utils:Helper functions` section.
+You can also find classes to plot the resulting interaction fingerprints in the
+:ref:`source/modules/plotting:Plotting` section

--- a/docs/source/modules/plotting.rst
+++ b/docs/source/modules/plotting.rst
@@ -1,5 +1,5 @@
 Plotting
-=========
+========
 
 .. automodule:: prolif.plotting.network
     :members:

--- a/docs/source/modules/plotting.rst
+++ b/docs/source/modules/plotting.rst
@@ -1,0 +1,5 @@
+Plotting
+=========
+
+.. automodule:: prolif.plotting.network
+    :members:

--- a/docs/source/modules/plotting.rst
+++ b/docs/source/modules/plotting.rst
@@ -2,4 +2,3 @@ Plotting
 ========
 
 .. automodule:: prolif.plotting.network
-    :members:

--- a/prolif/__init__.py
+++ b/prolif/__init__.py
@@ -8,6 +8,7 @@ from .utils import (get_residues_near_ligand,
                     to_dataframe,
                     to_bitvectors)
 from . import datafiles
+from . import plotting
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/prolif/__init__.py
+++ b/prolif/__init__.py
@@ -8,7 +8,6 @@ from .utils import (get_residues_near_ligand,
                     to_dataframe,
                     to_bitvectors)
 from . import datafiles
-from . import plotting
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -217,7 +217,7 @@ class Fingerprint:
         pro_atoms : list
             A list containing indices for the protein atoms responsible for
             each interaction
-        
+
         .. versionchanged:: 0.3.2
             Returns atom indices as two separate lists instead of a single list
             of tuples

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -11,13 +11,14 @@ Calculate a Protein-Ligand Interaction Fingerprint --- :mod:`prolif.fingerprint`
     u = mda.Universe(prolif.datafiles.TOP, prolif.datafiles.TRAJ)
     prot = u.select_atoms("protein")
     lig = u.select_atoms("resname LIG")
-    fp = prolif.Fingerprint(["HBDonor", "HBAcceptor", "PiStacking", "CationPi", "Cationic"])
+    fp = prolif.Fingerprint(["HBDonor", "HBAcceptor", "PiStacking", "CationPi",
+                             "Cationic"])
     fp.run(u.trajectory[::10], lig, prot)
     df = fp.to_dataframe()
     df
     bv = fp.to_bitvectors()
     TanimotoSimilarity(bv[0], bv[1])
-    
+
 """
 from functools import wraps
 import numpy as np
@@ -96,7 +97,8 @@ class Fingerprint:
 
         prot = u.select_atoms("protein")
         lig = u.select_atoms("resname LIG")
-        fp = prolif.Fingerprint(["HBDonor", "HBAcceptor", "PiStacking", "Hydrophobic"])
+        fp = prolif.Fingerprint(["HBDonor", "HBAcceptor", "PiStacking",
+                                 "Hydrophobic"])
         fp.run(u.trajectory[:5], lig, prot)
         fp.to_dataframe()
 
@@ -113,16 +115,18 @@ class Fingerprint:
 
     .. ipython:: python
 
-        fp.hbdonor(lig, prot["ASP129.A"]) # ligand-protein
-        fp.hbacceptor(prot["ASP129.A"], prot["CYS133.A"]) # protein-protein (alpha helix)
-    
+        # ligand-protein
+        fp.hbdonor(lig, prot["ASP129.A"])
+        # protein-protein (alpha helix)
+        fp.hbacceptor(prot["ASP129.A"], prot["CYS133.A"])
+
     You can also obtain the indices of atoms responsible for the interaction:
 
     .. ipython:: python
 
         fp.bitvector_atoms(lig, prot["ASP129.A"])
         fp.hbdonor.__wrapped__(lig, prot["ASP129.A"])
-    
+
     """
 
     def __init__(self, interactions=["Hydrophobic", "HBDonor", "HBAcceptor",
@@ -130,7 +134,7 @@ class Fingerprint:
         # read interactions to compute
         self.interactions = {}
         if interactions == "all":
-            interactions = [i for i in _INTERACTIONS.keys() 
+            interactions = [i for i in _INTERACTIONS.keys()
                             if not (i.startswith("_") or i == "Interaction")]
         for name, interaction_cls in _INTERACTIONS.items():
             if name.startswith("_") or name == "Interaction":
@@ -141,7 +145,7 @@ class Fingerprint:
             if name in interactions:
                 self.interactions[name] = func
 
-    def __repr__(self): # pragma: no cover
+    def __repr__(self):  # pragma: no cover
         name = ".".join([self.__class__.__module__, self.__class__.__name__])
         params = f"{self.n_interactions} interactions: {list(self.interactions.keys())}"
         return f"<{name}: {params} at {id(self):#x}>"
@@ -149,7 +153,7 @@ class Fingerprint:
     @staticmethod
     def list_available(show_hidden=False):
         """List interactions available to the Fingerprint class.
-        
+
         Parameters
         ----------
         show_hidden : bool
@@ -238,11 +242,11 @@ class Fingerprint:
         residues : list or "all" or None
             A list of protein residues (:class:`str`, :class:`int` or
             :class:`~prolif.residue.ResidueId`) to take into account for
-            the fingerprint extraction.
-            If ``"all"``, all residues will be used.
-            If ``None``, at each frame the :func:`~prolif.utils.get_residues_near_ligand`
-            function is used to automatically use protein residues that are
-            distant of 6.0 Å or less from each ligand residue.
+            the fingerprint extraction. If ``"all"``, all residues will be
+            used. If ``None``, at each frame the
+            :func:`~prolif.utils.get_residues_near_ligand` function is used to
+            automatically use protein residues that are distant of 6.0 Å or
+            less from each ligand residue.
         return_atoms : bool
             For each residue pair and interaction, return indices of atoms
             responsible for the interaction instead of bits.
@@ -267,7 +271,7 @@ class Fingerprint:
             >>> fp = prolif.Fingerprint()
             >>> ifp = fp.generate(lig, prot)
 
-        .. versionadded: 0.3.2
+        .. versionadded:: 0.3.2
         """
         ifp = {}
         resids = residues
@@ -284,7 +288,6 @@ class Fingerprint:
                 else:
                     ifp[key] = self.bitvector(lres, pres)
         return ifp
-                
 
     def run(self, traj, lig, prot, residues=None, progress=True):
         """Generates the fingerprint on a trajectory for a ligand and a protein
@@ -301,11 +304,11 @@ class Fingerprint:
         residues : list or "all" or None
             A list of protein residues (:class:`str`, :class:`int` or
             :class:`~prolif.residue.ResidueId`) to take into account for
-            the fingerprint extraction.
-            If ``"all"``, all residues will be used.
-            If ``None``, at each frame the :func:`~prolif.utils.get_residues_near_ligand`
-            function is used to automatically use protein residues that are
-            distant of 6.0 Å or less from each ligand residue.
+            the fingerprint extraction. If ``"all"``, all residues will be
+            used. If ``None``, at each frame the
+            :func:`~prolif.utils.get_residues_near_ligand` function is used to
+            automatically use protein residues that are distant of 6.0 Å or
+            less from each ligand residue.
         progress : bool
             Use the `tqdm <https://tqdm.github.io/>`_ package to display a
             progressbar while running the calculation
@@ -324,7 +327,7 @@ class Fingerprint:
             >>> prot = u.select_atoms("protein")
             >>> fp = prolif.Fingerprint().run(u.trajectory[:10], lig, prot)
 
-        .. versionchanged : 0.3.2
+        .. versionchanged:: 0.3.2
             Moved the ``return_atoms`` parameter from the ``run`` method to the
             dataframe conversion code
         """
@@ -343,7 +346,7 @@ class Fingerprint:
         return self
 
     def run_from_iterable(self, lig_iterable, prot_mol, residues=None,
-        progress=True):
+                          progress=True):
         """Generates the fingerprint between a list of ligands and a protein
 
         Parameters
@@ -356,11 +359,11 @@ class Fingerprint:
         residues : list or "all" or None
             A list of protein residues (:class:`str`, :class:`int` or
             :class:`~prolif.residue.ResidueId`) to take into account for
-            the fingerprint extraction.
-            If ``"all"``, all residues will be used.
-            If ``None``, at each frame the :func:`~prolif.utils.get_residues_near_ligand`
-            function is used to automatically use protein residues that are
-            distant of 6.0 Å or less from each ligand residue.
+            the fingerprint extraction. If ``"all"``, all residues will be
+            used. If ``None``, at each frame the
+            :func:`~prolif.utils.get_residues_near_ligand` function is used to
+            automatically use protein residues that are distant of 6.0 Å or
+            less from each ligand residue.
         progress : bool
             Use the `tqdm <https://tqdm.github.io/>`_ package to display a
             progressbar while running the calculation
@@ -369,7 +372,7 @@ class Fingerprint:
         -------
         prolif.fingerprint.Fingerprint
             The Fingerprint instance that generated the fingerprint
-        
+
         Example
         -------
         ::
@@ -385,7 +388,7 @@ class Fingerprint:
         See :meth:`~Fingerprint.generate` to generate the fingerprint between
         two single structures
 
-        .. versionchanged : 0.3.2
+        .. versionchanged:: 0.3.2
             Moved the ``return_atoms`` parameter from the ``run_from_iterable``
             method to the dataframe conversion code
         """
@@ -426,7 +429,7 @@ class Fingerprint:
         ------
         AttributeError
             If the :meth:`run` method hasn't been used
-        
+
         Example
         -------
         ::

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -20,7 +20,6 @@ Calculate a Protein-Ligand Interaction Fingerprint --- :mod:`prolif.fingerprint`
     
 """
 from functools import wraps
-from collections.abc import Iterable
 import numpy as np
 from tqdm.auto import tqdm
 from .interactions import _INTERACTIONS
@@ -390,8 +389,6 @@ class Fingerprint:
             method to the dataframe conversion code
         """
         iterator = tqdm(lig_iterable) if progress else lig_iterable
-        # set which residues to use
-        select_residues = False
         if residues == "all":
             residues = prot_mol.residues.keys()
         ifp = []

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -270,12 +270,13 @@ class Fingerprint:
         .. versionadded: 0.3.2
         """
         ifp = {}
+        resids = residues
         if residues == "all":
-            residues = prot.residues.keys()
+            resids = prot.residues.keys()
         for lresid, lres in lig.residues.items():
             if residues is None:
-                residues = get_residues_near_ligand(lres, prot)
-            for prot_key in residues:
+                resids = get_residues_near_ligand(lres, prot)
+            for prot_key in resids:
                 pres = prot[prot_key]
                 key = (lresid, pres.resid)
                 if return_atoms:

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -188,7 +188,6 @@ class Fingerprint:
         -------
         bitvector : numpy.ndarray
             An array storing the encoded interactions between res1 and res2
-
         """
         bitvector = []
         for func in self.interactions.values():
@@ -218,6 +217,10 @@ class Fingerprint:
         pro_atoms : list
             A list containing indices for the protein atoms responsible for
             each interaction
+        
+        .. versionchanged:: 0.3.2
+            Returns atom indices as two separate lists instead of a single list
+            of tuples
         """
         bitvector = []
         lig_atoms = []
@@ -259,7 +262,7 @@ class Fingerprint:
 
             - A single bitvector if ``return_atoms=False``
             - A tuple of bitvector, ligand atom indices and protein atom
-              indices if``return_atoms=True``
+              indices if ``return_atoms=True``
 
         Example
         -------

--- a/prolif/interactions.py
+++ b/prolif/interactions.py
@@ -127,7 +127,7 @@ class Hydrophobic(_Distance):
         Cutoff distance for the interaction
     """
     def __init__(self,
-                 hydrophobic="[#6,#16,F,Cl,Br,I,At;!$([+{1-},-{1-}])]",
+                 hydrophobic="[#6,#16,F,Cl,Br,I,At;+0]",
                  distance=4.5):
         super().__init__(hydrophobic, hydrophobic, distance)
 

--- a/prolif/plotting/__init__.py
+++ b/prolif/plotting/__init__.py
@@ -1,0 +1,1 @@
+from . import network

--- a/prolif/plotting/__init__.py
+++ b/prolif/plotting/__init__.py
@@ -1,1 +1,0 @@
-from . import network

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -6,7 +6,6 @@ import re
 from html import escape
 import pandas as pd
 import numpy as np
-from IPython.display import HTML
 from rdkit import Chem
 from rdkit.Chem import rdDepictor
 from ..residue import ResidueId
@@ -108,6 +107,7 @@ class LigNetwork:
         <html>
         <head>
         <script type="text/javascript" src="https://unpkg.com/vis-network@9.0.4/dist/vis-network.min.js"></script>
+        <link href="https://unpkg.com/vis-network@9.0.4/dist/dist/vis-network.min.css" rel="stylesheet" type="text/css" />
         <style type="text/css">
             body { padding: 0; margin: 0; }
             .legend-btn.residues.disabled {

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -617,7 +617,7 @@ class LigNetwork:
 
     @requires("IPython.display")
     def show(self, filename, **kwargs):
-        """Save and display the network"""
+        """Save the network as HTML and display the resulting file"""
         html = self._get_html(**kwargs)
         with open(filename, "w") as f:
             f.write(html)
@@ -625,3 +625,9 @@ class LigNetwork:
                   'src="{filename}"></iframe>')
         return HTML(iframe.format(width=self.width, height=self.height,
                                   filename=filename))
+
+    def save(self, filename, **kwargs):
+        """Save the network to an HTML file"""
+        html = self._get_html(**kwargs)
+        with open(filename, "w") as f:
+            f.write(html)

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -1,3 +1,7 @@
+"""
+Plot a Ligand Interaction Network --- :mod:`prolif.plotting.network`
+====================================================================
+"""
 from copy import deepcopy
 from collections import defaultdict
 import warnings
@@ -209,7 +213,8 @@ class LigNetwork:
     @classmethod
     def from_ifp(cls, ifp, lig, kind="aggregate", frame=0, threshold=.3,
         **kwargs):
-        """Creates a ligand interaction diagram from an IFP
+        """Helper method to create a ligand interaction diagram from an IFP
+        DataFrame obtained with ``fp.to_dataframe(return_atoms=True)``
 
         Notes
         -----
@@ -222,7 +227,7 @@ class LigNetwork:
         Parameters
         ----------
         ifp : pandas.DataFrame
-            The result of ``fp.to_dataframe()``
+            The result of ``fp.to_dataframe(return_atoms=True)``
         lig : MDAnalysis.core.groups.AtomGroup
             Ligand AtomGroup
         kind : str

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -624,4 +624,4 @@ class LigNetwork:
         iframe = ('<iframe width="{width}" height="{height}" frameborder="0" '
                   'src="{filename}"></iframe>')
         return HTML(iframe.format(width=self.width, height=self.height,
-                                  filename=html))
+                                  filename=filename))

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -1,6 +1,10 @@
 """
 Plot a Ligand Interaction Network --- :mod:`prolif.plotting.network`
 ====================================================================
+
+.. autoclass:: LigNetwork
+   :members:
+
 """
 from copy import deepcopy
 from collections import defaultdict
@@ -275,8 +279,7 @@ class LigNetwork:
                                    prefix_sep=", ")
                       .rename(columns=lambda x:
                               x.translate({ord(c): None for c in "()'"}))
-                      .mean()
-                   )
+                      .mean())
             index = [i.split(", ") for i in data.index]
             index = [[j for j in i[:-1]+[int(float(i[-1]))]] for i in index]
             data.index = pd.MultiIndex.from_tuples(
@@ -295,8 +298,7 @@ class LigNetwork:
                     .sort_values("weight", ascending=False)
                     .groupby(level=["ligand", "protein", "interaction"])
                     .head(1)
-                    .sort_index()
-                   )
+                    .sort_index())
             return cls(data, lig, **kwargs)
         elif kind == "frame":
             data = (ifp
@@ -305,8 +307,7 @@ class LigNetwork:
                     .applymap(lambda x: x[0])
                     .dropna()
                     .astype(int)
-                    .reset_index()
-                   )
+                    .reset_index())
             data.rename(columns={data.columns[-1]: "atom"}, inplace=True)
             data["weight"] = 1
             data.set_index(["ligand", "protein", "interaction", "atom"],
@@ -553,7 +554,7 @@ class LigNetwork:
                 color = node["color"]
                 available[color] = map_color_restype.get(color, "Unknown")
         available = {k: v for k, v in sorted(available.items(),
-                                             key=lambda item: item[1])}       
+                                             key=lambda item: item[1])}   
         for i, (color, restype) in enumerate(available.items()):
             buttons.append({
                 "index": i,

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -30,20 +30,6 @@ else:
 class LigNetwork:
     """Creates a ligand interaction diagram
 
-    Attributes
-    ----------
-    COLORS : dict
-        Dictionnary of colors used in the diagram. Subdivided in several
-        dictionaries:
-
-        - "interactions": mapping between interactions types and colors
-        - "atoms": mapping between atom symbol and colors
-        - "residues": mapping between residues types and colors
-
-    RESIDUE_TYPES : dict
-        Mapping between residue names (3 letter code) and types. The types
-        are then used to define how each residue should be colored.
-
     Parameters
     ----------
     df : pandas.DataFrame
@@ -65,6 +51,20 @@ class LigNetwork:
     carbon : float
         Size of the carbon atom dots on the depiction. Use `0` to hide the
         carbon dots
+
+    Attributes
+    ----------
+    COLORS : dict
+        Dictionnary of colors used in the diagram. Subdivided in several
+        dictionaries:
+
+        - "interactions": mapping between interactions types and colors
+        - "atoms": mapping between atom symbol and colors
+        - "residues": mapping between residues types and colors
+
+    RESIDUE_TYPES : dict
+        Mapping between residue names (3 letter code) and types. The types
+        are then used to define how each residue should be colored.
 
     Notes
     -----
@@ -555,7 +555,7 @@ class LigNetwork:
                 color = node["color"]
                 available[color] = map_color_restype.get(color, "Unknown")
         available = {k: v for k, v in sorted(available.items(),
-                                             key=lambda item: item[1])}   
+                                             key=lambda item: item[1])}
         for i, (color, restype) in enumerate(available.items()):
             buttons.append({
                 "index": i,

--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -146,27 +146,29 @@ def is_peptide_bond(bond, resids):
 
 
 def to_dataframe(ifp, interactions, index_col="Frame", dtype=None,
-                 drop_empty=True):
+                 drop_empty=True, return_atoms=False):
     """Converts IFPs to a pandas DataFrame
 
     Parameters
     ----------
     ifp : list
-        A list of dict in the format {key: bitvector} where
-        "bitvector" is a numpy.ndarray obtained by running the
-        :meth:`~prolif.fingerprint.Fingerprint.bitvector` method of a
-        :class:`~prolif.fingerprint.Fingerprint`, and "key" is a tuple of
-        ligand and protein ResidueId. Each dictionnary must also contain an
-        entry that will be used as an index, typically a frame number.
+        A list of dict in the format {key: bitvector}. "key" is a tuple of
+        ligand and protein ResidueId. "bitvector" is either a numpy.ndarray
+        of bits, or a list of bitarray, ligand atom indices, and protein atom
+        indices. Each dictionnary must also contain an entry that will be used
+        as an index, typically a frame number.
     interactions : list
         A list of interactions, in the same order as the bitvector.
     index_col : str
         The dictionnary key that will be used as an index in the DataFrame
     dtype : object or None
         Cast the input of each bit in the bitvector to this type. If None, keep
-        the data as is.
+        the data as is. Not compatible with ``return_atoms=True``
     drop_empty : bool
         Drop columns with only empty values
+    return_atoms : bool
+        For each residue pair and interaction, return indices of atoms
+        responsible for the interaction instead of bits
 
     Returns
     -------
@@ -187,7 +189,12 @@ def to_dataframe(ifp, interactions, index_col="Frame", dtype=None,
         0                       0          1           0           0          0
         ...
 
+    .. versionchanged : 0.3.2
+        Moved the `return_atoms` parameter from the `run` methods to the
+        dataframe conversion code
     """
+    if dtype and return_atoms:
+        raise ValueError("`dtype` cannot be used with `return_atoms=True`")
     ifp = deepcopy(ifp)
     n_interactions = len(interactions)
     empty_value = dtype(False) if dtype else False
@@ -198,9 +205,12 @@ def to_dataframe(ifp, interactions, index_col="Frame", dtype=None,
         if k in ifp[0].keys():
             break
     is_atompair = isinstance(ifp[0][k][0], Iterable)
+    if return_atoms and not is_atompair:
+        raise ValueError("The IFP either doesn't contain atom indices or is "
+                         "formatted incorrectly")
     # create empty array for each residue pair interaction that doesn't exist
     # in a particular frame
-    if is_atompair:
+    if is_atompair and return_atoms:
         empty_arr =  [[None, None]] * n_interactions
     else:
         empty_arr = np.array([empty_value] * n_interactions)
@@ -211,28 +221,40 @@ def to_dataframe(ifp, interactions, index_col="Frame", dtype=None,
         index.append(d.pop(index_col))
         for key in keys:
             try:
-                data[key].append(d[key])
+                arr = d[key]
             except KeyError:
                 data[key].append(empty_arr)
+            else:
+                if is_atompair and return_atoms:
+                    arr = list(zip(*arr[1:]))
+                elif is_atompair:
+                    arr = arr[0]
+                data[key].append(arr)
+    index = pd.Series(index, name=index_col)
     # create dataframes
     values = np.array([np.hstack([np.ravel(a[i]) for a in data.values()])
-                    for i in range(len(index))])
-    if is_atompair:
-        columns = pd.MultiIndex.from_tuples([(str(k[0]), str(k[1]), i, a) for k in keys
-                                        for i in interactions for a in ["ligand", "protein"]],
-                                        names=["ligand", "protein", "interaction", "atom"])
+                       for i in range(len(index))])
+    if is_atompair and return_atoms:
+        columns = pd.MultiIndex.from_tuples(
+            [(str(k[0]), str(k[1]), i, a)
+             for k in keys
+             for i in interactions
+             for a in ["ligand", "protein"]],
+            names=["ligand", "protein", "interaction", "atom"])
     else:
-        columns = pd.MultiIndex.from_tuples([(str(k[0]), str(k[1]), i) for k in keys
-                                        for i in interactions],
-                                        names=["ligand", "protein", "interaction"])
-    index = pd.Series(index, name=index_col)
+        columns = pd.MultiIndex.from_tuples(
+            [(str(k[0]), str(k[1]), i)
+             for k in keys
+             for i in interactions],
+            names=["ligand", "protein", "interaction"])
     df = pd.DataFrame(values, columns=columns, index=index)
-    if is_atompair:
-        df = df.groupby(axis=1, level=["ligand", "protein", "interaction"]).agg(tuple)
+    if is_atompair and return_atoms:
+        df = (df.groupby(axis=1, level=["ligand", "protein", "interaction"])
+                .agg(tuple))
     if dtype:
         df = df.astype(dtype)
     if drop_empty:
-        if is_atompair:
+        if is_atompair and return_atoms:
             mask = df.apply(lambda s:
                             ~(s.isin([(None, None)]).all()), axis=0)
         else:

--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -190,7 +190,7 @@ def to_dataframe(ifp, interactions, index_col="Frame", dtype=None,
         ...
 
     .. versionchanged:: 0.3.2
-        Moved the `return_atoms` parameter from the `run` methods to the
+        Moved the ``return_atoms`` parameter from the ``run`` methods to the
         dataframe conversion code
     """
     if dtype and return_atoms:

--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -69,7 +69,7 @@ def angle_between_limits(angle, min_angle, max_angle, ring=False):
 
 def get_residues_near_ligand(lig, prot, cutoff=6.0):
     """Detects residues close to a reference ligand
-    
+
     Parameters
     ----------
     lig : prolif.molecule.Molecule
@@ -189,7 +189,7 @@ def to_dataframe(ifp, interactions, index_col="Frame", dtype=None,
         0                       0          1           0           0          0
         ...
 
-    .. versionchanged : 0.3.2
+    .. versionchanged:: 0.3.2
         Moved the `return_atoms` parameter from the `run` methods to the
         dataframe conversion code
     """
@@ -211,7 +211,7 @@ def to_dataframe(ifp, interactions, index_col="Frame", dtype=None,
     # create empty array for each residue pair interaction that doesn't exist
     # in a particular frame
     if is_atompair and return_atoms:
-        empty_arr =  [[None, None]] * n_interactions
+        empty_arr = [[None, None]] * n_interactions
     else:
         empty_arr = np.array([empty_value] * n_interactions)
     # sparse to dense
@@ -277,7 +277,7 @@ def to_bitvectors(df):
     ----------
     df : pandas.DataFrame
         A DataFrame where each column corresponds to an interaction between two
-        residues 
+        residues
 
     Returns
     -------

--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -5,6 +5,8 @@ Helper functions --- :mod:`prolif.utils`
 from math import pi
 from collections import defaultdict
 from collections.abc import Iterable
+from functools import wraps
+from importlib.util import find_spec
 from copy import deepcopy
 import numpy as np
 import pandas as pd
@@ -18,6 +20,19 @@ from .residue import ResidueId
 
 
 _90_deg_to_rad = pi/2
+
+
+def requires(module):
+    def inner(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if find_spec(module):
+                return func(*args, **kwargs)
+            raise ModuleNotFoundError(
+                f"The module {module!r} is required to use {func.__name__!r} "
+                "but it is not installed!")
+        return wrapper
+    return inner
 
 
 def get_centroid(coordinates):

--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -22,7 +22,7 @@ from .residue import ResidueId
 _90_deg_to_rad = pi/2
 
 
-def requires(module):
+def requires(module):  # pragma: no cover
     def inner(func):
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ keywords =
     molecular-dynamics
 
 [options]
-packages = prolif
+packages = find:
 python_requires = >=3.6
 install_requires =
     pandas>=1.0.0
@@ -41,6 +41,9 @@ install_requires =
     tqdm
 zip_safe = False
 include_package_data = True
+
+[options.packages.find]
+exclude = tests
 
 [options.extras_require]
 tests =

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
 from setuptools import setup
 import versioneer
+import re
 
+# manually check RDKit version
+try:
+    from rdkit import __version__ as rdkit_version
+except ImportError:
+    raise ImportError("ProLIF requires RDKit but it is not installed")
+else:
+    if re.match(r"^20[0-1][0-9]\.", rdkit_version):
+        raise ValueError("ProLIF requires a version of RDKit >= 2020")
 
 setup(version=versioneer.get_version())

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -12,6 +12,7 @@ def lignetwork_data():
     fp = plf.Fingerprint(["Hydrophobic"])
     fp.run(u.trajectory, lig, prot)
     df = fp.to_dataframe(return_atoms=True)
+    lig = plf.Molecule.from_mda(lig)
     return lig, df
 
 

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -50,7 +50,7 @@ class TestLigNetwork:
 
     def test_kwargs(self, lignetwork_data):
         lig, df = lignetwork_data
-        net = LigNetwork.from_ifp(df, lig, kekulize=True, gen2D=True,
+        net = LigNetwork.from_ifp(df, lig, kekulize=True, match3D=False,
                                   rotation=42, carbon=0)
         with StringIO() as buffer:
             net.save(buffer)

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -1,0 +1,7 @@
+import prolif as plf
+from prolif.plotting.network import LigNetwork
+import pytest
+
+def test_from_ifp_raises_kind():
+    with pytest.raises(ValueError, match='must be "aggregate" or "frame"'):
+        LigNetwork.from_ifp(None, kind="foo")

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -3,19 +3,17 @@ import prolif as plf
 from prolif.plotting.network import LigNetwork
 import pytest
 
-def test_from_ifp_raises_kind():
-    with pytest.raises(ValueError, match='must be "aggregate" or "frame"'):
-        LigNetwork.from_ifp(None, kind="foo")
 
 @pytest.fixture(scope="module")
 def lignetwork_data():
     u = mda.Universe(plf.datafiles.TOP)
-    prot = u.select_atoms("protein")
+    prot = u.select_atoms("protein and resid 120-130")
     lig = u.select_atoms("resname LIG")
-    fp = plf.Fingerprint(["HBDonor"])
-    fp.run(u.trajectory, lig, prot, return_atoms=True)
-    df = fp.to_dataframe()
+    fp = plf.Fingerprint(["Hydrophobic"])
+    fp.run(u.trajectory, lig, prot)
+    df = fp.to_dataframe(return_atoms=True)
     return lig, df
+
 
 def test_integration_frame(lignetwork_data):
     lig, df = lignetwork_data
@@ -23,8 +21,15 @@ def test_integration_frame(lignetwork_data):
     html = net._get_html()
     assert html
 
+
 def test_integration_agg(lignetwork_data):
     lig, df = lignetwork_data
     net = LigNetwork.from_ifp(df, lig, kind="aggregate", threshold=0)
     html = net._get_html()
     assert html
+
+
+def test_from_ifp_raises_kind(lignetwork_data):
+    lig, df = lignetwork_data
+    with pytest.raises(ValueError, match='must be "aggregate" or "frame"'):
+        LigNetwork.from_ifp(df, lig, kind="foo")

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -1,3 +1,4 @@
+from io import StringIO
 import MDAnalysis as mda
 import prolif as plf
 from prolif.plotting.network import LigNetwork
@@ -7,9 +8,9 @@ class TestLigNetwork:
     @pytest.fixture(scope="class")
     def lignetwork_data(self):
         u = mda.Universe(plf.datafiles.TOP)
-        prot = u.select_atoms("protein and resid 120-130")
+        prot = u.select_atoms("protein and resid 200:331")
         lig = u.select_atoms("resname LIG")
-        fp = plf.Fingerprint(["Hydrophobic"])
+        fp = plf.Fingerprint()
         fp.run(u.trajectory, lig, prot)
         df = fp.to_dataframe(return_atoms=True)
         lig = plf.Molecule.from_mda(lig)
@@ -19,15 +20,32 @@ class TestLigNetwork:
     def test_integration_frame(self, lignetwork_data):
         lig, df = lignetwork_data
         net = LigNetwork.from_ifp(df, lig, kind="frame", frame=0)
-        html = net._get_html()
-        assert html
+        with StringIO() as buffer:
+            net.save(buffer)
+            buffer.seek(0)
+            html = buffer.read()
+        assert "PHE331.B" in html
 
 
     def test_integration_agg(self, lignetwork_data):
         lig, df = lignetwork_data
         net = LigNetwork.from_ifp(df, lig, kind="aggregate", threshold=0)
-        html = net._get_html()
-        assert html
+        with StringIO() as buffer:
+            net.save(buffer)
+            buffer.seek(0)
+            html = buffer.read()
+        assert "PHE331.B" in html
+
+
+    def test_kwargs(self, lignetwork_data):
+        lig, df = lignetwork_data
+        net = LigNetwork.from_ifp(df, lig, kekulize=True, gen2D=True,
+                                  rotation=42, carbon=0)
+        with StringIO() as buffer:
+            net.save(buffer)
+            buffer.seek(0)
+            html = buffer.read()
+        assert "PHE331.B" in html
 
 
     def test_from_ifp_raises_kind(self, lignetwork_data):

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -4,6 +4,7 @@ import prolif as plf
 from prolif.plotting.network import LigNetwork
 import pytest
 
+
 class TestLigNetwork:
     @pytest.fixture(scope="class")
     def lignetwork_data(self):
@@ -16,7 +17,6 @@ class TestLigNetwork:
         lig = plf.Molecule.from_mda(lig)
         return lig, df
 
-
     def test_integration_frame(self, lignetwork_data):
         lig, df = lignetwork_data
         net = LigNetwork.from_ifp(df, lig, kind="frame", frame=0)
@@ -25,7 +25,6 @@ class TestLigNetwork:
             buffer.seek(0)
             html = buffer.read()
         assert "PHE331.B" in html
-
 
     def test_integration_agg(self, lignetwork_data):
         lig, df = lignetwork_data
@@ -36,7 +35,6 @@ class TestLigNetwork:
             html = buffer.read()
         assert "PHE331.B" in html
 
-
     def test_kwargs(self, lignetwork_data):
         lig, df = lignetwork_data
         net = LigNetwork.from_ifp(df, lig, kekulize=True, gen2D=True,
@@ -46,7 +44,6 @@ class TestLigNetwork:
             buffer.seek(0)
             html = buffer.read()
         assert "PHE331.B" in html
-
 
     def test_from_ifp_raises_kind(self, lignetwork_data):
         lig, df = lignetwork_data

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -1,3 +1,4 @@
+import MDAnalysis as mda
 import prolif as plf
 from prolif.plotting.network import LigNetwork
 import pytest
@@ -5,3 +6,25 @@ import pytest
 def test_from_ifp_raises_kind():
     with pytest.raises(ValueError, match='must be "aggregate" or "frame"'):
         LigNetwork.from_ifp(None, kind="foo")
+
+@pytest.fixture(scope="module")
+def lignetwork_data():
+    u = mda.Universe(plf.datafiles.TOP)
+    prot = u.select_atoms("protein")
+    lig = u.select_atoms("resname LIG")
+    fp = plf.Fingerprint(["HBDonor"])
+    fp.run(u.trajectory, lig, prot, return_atoms=True)
+    df = fp.to_dataframe()
+    return lig, df
+
+def test_integration_frame(lignetwork_data):
+    lig, df = lignetwork_data
+    net = LigNetwork.from_ifp(df, lig, kind="frame", frame=0)
+    html = net._get_html()
+    assert html
+
+def test_integration_agg(lignetwork_data):
+    lig, df = lignetwork_data
+    net = LigNetwork.from_ifp(df, lig, kind="aggregate", threshold=0)
+    html = net._get_html()
+    assert html

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -3,34 +3,34 @@ import prolif as plf
 from prolif.plotting.network import LigNetwork
 import pytest
 
-
-@pytest.fixture(scope="module")
-def lignetwork_data():
-    u = mda.Universe(plf.datafiles.TOP)
-    prot = u.select_atoms("protein and resid 120-130")
-    lig = u.select_atoms("resname LIG")
-    fp = plf.Fingerprint(["Hydrophobic"])
-    fp.run(u.trajectory, lig, prot)
-    df = fp.to_dataframe(return_atoms=True)
-    lig = plf.Molecule.from_mda(lig)
-    return lig, df
-
-
-def test_integration_frame(lignetwork_data):
-    lig, df = lignetwork_data
-    net = LigNetwork.from_ifp(df, lig, kind="frame", frame=0)
-    html = net._get_html()
-    assert html
+class TestLigNetwork:
+    @pytest.fixture(scope="class")
+    def lignetwork_data(self):
+        u = mda.Universe(plf.datafiles.TOP)
+        prot = u.select_atoms("protein and resid 120-130")
+        lig = u.select_atoms("resname LIG")
+        fp = plf.Fingerprint(["Hydrophobic"])
+        fp.run(u.trajectory, lig, prot)
+        df = fp.to_dataframe(return_atoms=True)
+        lig = plf.Molecule.from_mda(lig)
+        return lig, df
 
 
-def test_integration_agg(lignetwork_data):
-    lig, df = lignetwork_data
-    net = LigNetwork.from_ifp(df, lig, kind="aggregate", threshold=0)
-    html = net._get_html()
-    assert html
+    def test_integration_frame(self, lignetwork_data):
+        lig, df = lignetwork_data
+        net = LigNetwork.from_ifp(df, lig, kind="frame", frame=0)
+        html = net._get_html()
+        assert html
 
 
-def test_from_ifp_raises_kind(lignetwork_data):
-    lig, df = lignetwork_data
-    with pytest.raises(ValueError, match='must be "aggregate" or "frame"'):
-        LigNetwork.from_ifp(df, lig, kind="foo")
+    def test_integration_agg(self, lignetwork_data):
+        lig, df = lignetwork_data
+        net = LigNetwork.from_ifp(df, lig, kind="aggregate", threshold=0)
+        html = net._get_html()
+        assert html
+
+
+    def test_from_ifp_raises_kind(self, lignetwork_data):
+        lig, df = lignetwork_data
+        with pytest.raises(ValueError, match='must be "aggregate" or "frame"'):
+            LigNetwork.from_ifp(df, lig, kind="foo")

--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -1,8 +1,21 @@
 from io import StringIO
+from tempfile import NamedTemporaryFile
+import os
+from contextlib import contextmanager
 import MDAnalysis as mda
 import prolif as plf
 from prolif.plotting.network import LigNetwork
 import pytest
+
+
+@contextmanager
+def TempFilename(mode='w'):
+    f = NamedTemporaryFile(delete=False, mode=mode)
+    try:
+        f.close()
+        yield f.name
+    finally:
+        os.unlink(f.name)
 
 
 class TestLigNetwork:
@@ -44,6 +57,14 @@ class TestLigNetwork:
             buffer.seek(0)
             html = buffer.read()
         assert "PHE331.B" in html
+
+    def test_save_file(self, lignetwork_data):
+        lig, df = lignetwork_data
+        net = LigNetwork.from_ifp(df, lig)
+        with TempFilename("w+") as filename:
+            net.save(filename)
+            with open(filename, "r") as f:
+                assert "PHE331.B" in f.read()
 
     def test_from_ifp_raises_kind(self, lignetwork_data):
         lig, df = lignetwork_data

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -68,12 +68,14 @@ class TestFingerprint:
         assert bv.sum() > 0
 
     def test_bitvector_atoms(self, fp):
-        bv, atoms = fp.bitvector_atoms(ligand_mol, protein_mol["ASP129.A"])
+        bv, lig_ix, prot_ix = fp.bitvector_atoms(ligand_mol,
+                                                 protein_mol["ASP129.A"])
         assert len(bv) == fp.n_interactions
-        assert len(atoms) == fp.n_interactions
+        assert len(lig_ix) == fp.n_interactions
+        assert len(prot_ix) == fp.n_interactions
         assert bv.sum() > 0
         ids = np.where(bv == 1)[0]
-        assert atoms[ids[0]] != (None, None)
+        assert (lig_ix[ids[0]] is not None and prot_ix[ids[0]] is not None)
 
     def test_run_residues(self, fp_class):
         fp_class.run(u.trajectory[0:1], ligand_ag, protein_ag,
@@ -104,13 +106,17 @@ class TestFingerprint:
         bv = ifp[key]
         assert isinstance(bv, np.ndarray)
         assert bv[0] == True
+
+    def test_run(self, fp_class):
         fp_class.run(u.trajectory[0:1], ligand_ag, protein_ag,
-                     residues=None, progress=False, return_atoms=True)
+                     residues=None, progress=False)
         assert hasattr(fp_class, "ifp")
         ifp = fp_class.ifp[0]
         ifp.pop("Frame")
-        atom_pair = list(ifp.values())[0]
-        assert isinstance(atom_pair, list)
+        data = list(ifp.values())[0]
+        assert isinstance(data[0], np.ndarray)
+        assert isinstance(data[1], list)
+        assert isinstance(data[2], list)
     
     def test_run_from_iterable(self, fp):
         path = str(datapath / "vina" / "vina_output.sdf")
@@ -119,7 +125,7 @@ class TestFingerprint:
         assert len(fp.ifp) == 2
 
     def test_to_df(self, fp, fp_class):
-        with pytest.raises(AttributeError, match="use the run method"):
+        with pytest.raises(AttributeError, match="use the `run` method"):
             fp.to_dataframe()
         fp_class.run(u.trajectory[:3], ligand_ag, protein_ag,
                      residues=None, progress=False)
@@ -138,7 +144,7 @@ class TestFingerprint:
         assert df.shape == (3, len(resids))
 
     def test_to_bv(self, fp, fp_class):
-        with pytest.raises(AttributeError, match="use the run method"):
+        with pytest.raises(AttributeError, match="use the `run` method"):
             fp.to_bitvectors()
         fp_class.run(u.trajectory[:3], ligand_ag, protein_ag,
                      residues=None, progress=False)

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -105,7 +105,7 @@ class TestFingerprint:
         key = (ResidueId("LIG", 1, "G"), ResidueId("THR", 355, "B"))
         bv = ifp[key]
         assert isinstance(bv, np.ndarray)
-        assert bv[0] == True
+        assert bv[0] is True
 
     def test_run(self, fp_class):
         fp_class.run(u.trajectory[0:1], ligand_ag, protein_ag,
@@ -117,7 +117,7 @@ class TestFingerprint:
         assert isinstance(data[0], np.ndarray)
         assert isinstance(data[1], list)
         assert isinstance(data[2], list)
-    
+
     def test_run_from_iterable(self, fp):
         path = str(datapath / "vina" / "vina_output.sdf")
         lig_suppl = list(sdf_supplier(path))
@@ -140,7 +140,7 @@ class TestFingerprint:
         assert df.dtypes[0].type is np.uint8
         df = fp_class.to_dataframe(drop_empty=False)
         resids = set([key for d in fp_class.ifp for key in d.keys()
-                  if key != "Frame"])
+                      if key != "Frame"])
         assert df.shape == (3, len(resids))
 
     def test_to_bv(self, fp, fp_class):

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -105,7 +105,7 @@ class TestFingerprint:
         key = (ResidueId("LIG", 1, "G"), ResidueId("THR", 355, "B"))
         bv = ifp[key]
         assert isinstance(bv, np.ndarray)
-        assert bv[0] is True
+        assert bv[0] is np.True_
 
     def test_run(self, fp_class):
         fp_class.run(u.trajectory[0:1], ligand_ag, protein_ag,

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -98,7 +98,12 @@ class TestFingerprint:
         assert (lig_id, res) in fp_class.ifp[0].keys()
         u.trajectory[0]
 
-    def test_run_return_atoms(self, fp_class):
+    def test_generate(self, fp_class):
+        ifp = fp_class.generate(ligand_mol, protein_mol)
+        key = (ResidueId("LIG", 1, "G"), ResidueId("THR", 355, "B"))
+        bv = ifp[key]
+        assert isinstance(bv, np.ndarray)
+        assert bv[0] == True
         fp_class.run(u.trajectory[0:1], ligand_ag, protein_ag,
                      residues=None, progress=False, return_atoms=True)
         assert hasattr(fp_class, "ifp")

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -87,7 +87,8 @@ class TestInteractions:
         with pytest.warns(UserWarning,
                           match="interaction has been superseded"):
             class Hydrophobic(Interaction):
-                pass
+                def detect(self):
+                    pass
         new = id(_INTERACTIONS["Hydrophobic"])
         assert old != new
 

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -98,6 +98,10 @@ class TestInteractions:
         with pytest.raises(TypeError,
                            match="Can't instantiate abstract class Dummy"):
             Dummy()
+        # fix Dummy class being instanciated in later unrelated tests
+        class Dummy(Interaction):
+            def detect(self):
+                pass
 
     @pytest.mark.parametrize("index", [
         0, 1, 3, 42, 78

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -2,6 +2,7 @@ import pytest
 from rdkit import RDLogger
 from prolif.fingerprint import Fingerprint
 from prolif.interactions import _INTERACTIONS, Interaction, get_mapindex
+import prolif
 from .test_base import ligand_mol
 from . import mol2factory
 
@@ -91,6 +92,9 @@ class TestInteractions:
                     pass
         new = id(_INTERACTIONS["Hydrophobic"])
         assert old != new
+        # fix dummy Hydrophobic class being reused in later unrelated tests
+        class Hydrophobic(prolif.interactions.Hydrophobic):
+            pass
 
     def test_error_no_detect(self):
         class Dummy(Interaction):
@@ -98,7 +102,7 @@ class TestInteractions:
         with pytest.raises(TypeError,
                            match="Can't instantiate abstract class Dummy"):
             Dummy()
-        # fix Dummy class being instanciated in later unrelated tests
+        # fix Dummy class being reused in later unrelated tests
         class Dummy(Interaction):
             def detect(self):
                 pass

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -10,9 +10,11 @@ from . import mol2factory
 lg = RDLogger.logger()
 lg.setLevel(RDLogger.ERROR)
 
+
 @pytest.fixture(scope="module")
 def mol1(request):
     return getattr(mol2factory, request.param)()
+
 
 @pytest.fixture(scope="module")
 def mol2(request):
@@ -93,6 +95,7 @@ class TestInteractions:
         new = id(_INTERACTIONS["Hydrophobic"])
         assert old != new
         # fix dummy Hydrophobic class being reused in later unrelated tests
+
         class Hydrophobic(prolif.interactions.Hydrophobic):
             pass
 
@@ -103,9 +106,7 @@ class TestInteractions:
                            match="Can't instantiate abstract class Dummy"):
             Dummy()
         # fix Dummy class being reused in later unrelated tests
-        class Dummy(Interaction):
-            def detect(self):
-                pass
+        del prolif.interactions._INTERACTIONS["Dummy"]
 
     @pytest.mark.parametrize("index", [
         0, 1, 3, 42, 78

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,11 +106,11 @@ ifp = [{"Frame": 0,
         ("LIG", "ASP3"): np.array([False, True, False])}]
 
 ifp_atoms = [{"Frame": 0,
-              ("LIG", "ALA1"): [[0, 1], [None, None], [None, None]],
-              ("LIG", "GLU2"): [[None, None], [1, 3], [None, None]]},
+              ("LIG", "ALA1"): [[1, 0, 0], [0, None, None], [1, None, None]],
+              ("LIG", "GLU2"): [[0, 1, 0], [None, 1, None], [None, 3, None]]},
              {"Frame": 1,
-              ("LIG", "ALA1"): [[2, 4], [2, 5], [None, None]],
-              ("LIG", "ASP3"): [[None, None], [8, 10], [None, None]]}]
+              ("LIG", "ALA1"): [[1, 1, 0], [2, 2, None], [4, 5, None]],
+              ("LIG", "ASP3"): [[0, 1, 0], [None, 8, None], [None, 10, None]]}]
 
 
 def test_to_df():
@@ -129,7 +129,7 @@ def test_to_df():
 
 
 def test_to_df_atom_pairs():
-    df = to_dataframe(ifp_atoms, ["A", "B", "C"])
+    df = to_dataframe(ifp_atoms, ["A", "B", "C"], return_atoms=True)
     assert df.shape == (2, 4)
     assert df.index.name == "Frame"
     assert ("LIG", "ALA1", "A") in df.columns
@@ -156,6 +156,18 @@ def test_to_df_dtype(dtype):
 def test_to_df_drop_empty():
     df = to_dataframe(ifp, ["A", "B", "C"], drop_empty=False)
     assert df.shape == (2, 9)
+
+
+def test_to_df_raise_dtype_return_atoms():
+    with pytest.raises(ValueError,
+        match="`dtype` cannot be used with `return_atoms=True`"
+        ):
+        to_dataframe(ifp_atoms, ["A", "B", "C"], dtype=int, return_atoms=True)
+
+
+def test_to_df_raise_return_atoms_if_only_bitvector():
+    with pytest.raises(ValueError, match="doesn't contain atom indices"):
+        to_dataframe(ifp, ["A", "B", "C"], return_atoms=True)
 
 
 def test_to_bv():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,12 +16,12 @@ from .test_base import ligand_mol, protein_mol
 
 
 def test_centroid():
-    xyz = np.array([(0,0,0),
-                    (0,0,0),
-                    (0,0,0),
-                    (2,2,2),
-                    (2,2,2),
-                    (2,2,2)],
+    xyz = np.array([(0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (2, 2, 2),
+                    (2, 2, 2),
+                    (2, 2, 2)],
                    dtype=np.float32)
     ctd = get_centroid(xyz)
     assert ctd.shape == (3,)
@@ -92,7 +92,7 @@ def test_is_peptide_bond():
 
 
 def test_series_to_bv():
-    v = np.array([0,1,1,0,1])
+    v = np.array([0, 1, 1, 0, 1])
     bv = pandas_series_to_bv(v)
     assert bv.GetNumBits() == len(v)
     assert bv.GetNumOnBits() == 3
@@ -159,9 +159,10 @@ def test_to_df_drop_empty():
 
 
 def test_to_df_raise_dtype_return_atoms():
-    with pytest.raises(ValueError,
+    with pytest.raises(
+        ValueError,
         match="`dtype` cannot be used with `return_atoms=True`"
-        ):
+    ):
         to_dataframe(ifp_atoms, ["A", "B", "C"], dtype=int, return_atoms=True)
 
 


### PR DESCRIPTION
0.3.2 preparation PR

### Added
- LigNetwork: an interaction diagram with atomic details for the ligand and residue-level details for the protein, fully interactive in a browser/notebook. Inspired from LigPlot
- `fp.generate`: a method to get the IFP between two `prolif.Molecule` objects
### Changed
- The `Hydrophobic` interaction now uses `+0` (no charge) instead of `!$([+{1-},-{1-}])` (not negatively or positively charged) for part of its SMARTS pattern
- Moved the `return_atoms` parameter from the `run` methods to `to_dataframe` to avoid recalculating the IFP if one wants to display it with atomic details
- Changed the values returned by `fp.bitvector_atoms`: the atom indices have been separated in two lists (one for the ligand and one for the protein)