### PR TITLE
fix quickstart link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Dead link in the quickstart notebook for the MDAnalysis quickstart (PR #75, @radifar).
+
 ## [1.0.0] - 2022-06-07
 ### Added
 - Support for multiprocessing, enabled by default (Issue #46). The number of processes can

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -31,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "MDAnalysis should automatically recognize the file type that you're using from its extension. Click [here](https://userguide.mdanalysis.org/stable/quickstart.html) to learn more about loading files with MDAnalysis, and [here](https://userguide.mdanalysis.org/stable/selections.html) to learn more about their atom selection language.\n",
+    "MDAnalysis should automatically recognize the file type that you're using from its extension. Click [here](https://userguide.mdanalysis.org/stable/examples/quickstart.html) to learn more about loading files with MDAnalysis, and [here](https://userguide.mdanalysis.org/stable/selections.html) to learn more about their atom selection language.\n",
     "\n",
     "Next, lets make sure that our ligand was correctly read by MDAnalysis.\n",
     "\n",


### PR DESCRIPTION
Just found a dead link. And this PR is to update the mdanalysis quickstart link.