### PR TITLE
Pass parameters to the RDKitConverter from MDAnalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Dead link in the quickstart notebook for the MDAnalysis quickstart (PR #75, @radifar).
 
+### Added
+- `Fingerprint.run` now has a `converter_kwargs` parameter that can pass kwargs to the
+  underlying RDKitConverter from MDAnalysis (Issue #57).
+
 ## [1.0.0] - 2022-06-07
 ### Added
 - Support for multiprocessing, enabled by default (Issue #46). The number of processes can

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ html_static_path = [] # ['_static']
 
 intersphinx_mapping = {'https://docs.python.org/3/': None,
                        'https://numpy.org/doc/stable/': None,
-                       'https://docs.mdanalysis.org/': None,
+                       'https://docs.mdanalysis.org/stable/': None,
                        'https://www.rdkit.org/docs/': None,
                        'https://pandas.pydata.org/docs/': None,
                        }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ html_static_path = [] # ['_static']
 
 intersphinx_mapping = {'https://docs.python.org/3/': None,
                        'https://numpy.org/doc/stable/': None,
-                       'https://docs.mdanalysis.org/2.0.0-dev0/': None,
+                       'https://docs.mdanalysis.org/': None,
                        'https://www.rdkit.org/docs/': None,
                        'https://pandas.pydata.org/docs/': None,
                        }

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -384,12 +384,12 @@ class Fingerprint:
 
         Parameters
         ----------
-        traj : MDAnalysis.coordinates.base.ProtoReader or MDAnalysis.coordinates.base.FrameIteratorSliced
+        traj : mda.coordinates.base.ProtoReader or mda.coordinates.base.FrameIteratorSliced
             Iterate over this Universe trajectory or sliced trajectory object
             to extract the frames used for the fingerprint extraction
-        lig : MDAnalysis.core.groups.AtomGroup
+        lig : mda.core.groups.AtomGroup
             An MDAnalysis AtomGroup for the ligand
-        prot : MDAnalysis.core.groups.AtomGroup
+        prot : mda.core.groups.AtomGroup
             An MDAnalysis AtomGroup for the protein (with multiple residues)
         residues : list or "all" or None
             A list of protein residues (:class:`str`, :class:`int` or
@@ -400,7 +400,7 @@ class Fingerprint:
             automatically use protein residues that are distant of 6.0 Å or
             less from each ligand residue.
         converter_kwargs : list or None
-            List of kwargs passed to the underlying :class:`~MDAnalysis.converters.RDKit.RDKitConverter`
+            List of kwargs passed to the underlying :class:`~mda.converters.RDKit.RDKitConverter`
             from MDAnalysis: the first for the ligand, and the second for the protein
         progress : bool
             Use the `tqdm <https://tqdm.github.io/>`_ package to display a

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -400,8 +400,8 @@ class Fingerprint:
             automatically use protein residues that are distant of 6.0 Å or
             less from each ligand residue.
         converter_kwargs : list or None
-            List of kwargs passed to the underlying RDKitConverter from MDAnalysis: the
-            first for the ligand, and the second for the protein
+            List of kwargs passed to the underlying :class:`~MDAnalysis.converters.RDKit.RDKitConverter`
+            from MDAnalysis: the first for the ligand, and the second for the protein
         progress : bool
             Use the `tqdm <https://tqdm.github.io/>`_ package to display a
             progressbar while running the calculation

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -379,7 +379,7 @@ class Fingerprint:
                     ifp[key] = self.bitvector(lres, pres)
         return ifp
 
-    def run(self, traj, lig, prot, residues=None, progress=True, n_jobs=None):
+    def run(self, traj, lig, prot, residues=None, converter_kwargs=None, progress=True, n_jobs=None):
         """Generates the fingerprint on a trajectory for a ligand and a protein
 
         Parameters
@@ -399,6 +399,9 @@ class Fingerprint:
             :func:`~prolif.utils.get_residues_near_ligand` function is used to
             automatically use protein residues that are distant of 6.0 Å or
             less from each ligand residue.
+        converter_kwargs : list or None
+            List of kwargs passed to the underlying RDKitConverter from MDAnalysis: the
+            first for the ligand, and the second for the protein
         progress : bool
             Use the `tqdm <https://tqdm.github.io/>`_ package to display a
             progressbar while running the calculation
@@ -438,21 +441,28 @@ class Fingerprint:
 
         .. versionchanged:: 1.0.0
             Added support for multiprocessing
+        
+        .. versionadded:: 1.0.1
+            Added support for passing kwargs to the RDKitConverter
 
         """
         if n_jobs is not None and n_jobs < 1:
             raise ValueError("n_jobs must be > 0 or None")
+        if converter_kwargs is not None and len(converter_kwargs) != 2:
+            raise ValueError("converter_kwargs must be a list of 2 dicts")
         if n_jobs != 1:
             return self._run_parallel(traj, lig, prot, residues=residues,
+                                      converter_kwargs=converter_kwargs,
                                       progress=progress, n_jobs=n_jobs)
+        lig_kwargs, prot_kwargs = converter_kwargs or ({}, {})
 
         iterator = tqdm(traj) if progress else traj
         if residues == "all":
-            residues = Molecule.from_mda(prot).residues.keys()
+            residues = Molecule.from_mda(prot, **prot_kwargs).residues.keys()
         ifp = []
         for ts in iterator:
-            prot_mol = Molecule.from_mda(prot)
-            lig_mol = Molecule.from_mda(lig)
+            prot_mol = Molecule.from_mda(prot, **prot_kwargs)
+            lig_mol = Molecule.from_mda(lig, **lig_kwargs)
             data = self.generate(lig_mol, prot_mol, residues=residues,
                                  return_atoms=True)
             data["Frame"] = ts.frame
@@ -460,8 +470,8 @@ class Fingerprint:
         self.ifp = ifp
         return self
 
-    def _run_parallel(self, traj, lig, prot, residues=None, progress=True,
-                      n_jobs=None):
+    def _run_parallel(self, traj, lig, prot, residues=None, converter_kwargs=None,
+                      progress=True, n_jobs=None):
         """Parallel implementation of :meth:`~Fingerprint.run`"""
         n_chunks = n_jobs if n_jobs else mp.cpu_count()
         try:
@@ -472,9 +482,10 @@ class Fingerprint:
             traj = lig.universe.trajectory
         else:
             frames = range(n_frames)
+        lig_kwargs, prot_kwargs = converter_kwargs or ({}, {})
 
         if residues == "all":
-            residues = Molecule.from_mda(prot).residues.keys()
+            residues = Molecule.from_mda(prot, **prot_kwargs).residues.keys()
         chunks = np.array_split(frames, n_chunks)
         # setup parallel progress bar
         pcount = ProgressCounter()
@@ -486,7 +497,7 @@ class Fingerprint:
 
         # run pool of workers
         with mp.Pool(n_jobs, initializer=declare_shared_objs_for_chunk,
-                     initargs=(self, residues, progress, pcount)) as pool:
+                     initargs=(self, residues, progress, pcount, (lig_kwargs, prot_kwargs))) as pool:
             pbar_thread.start()
             args = ((traj, lig, prot, chunk) for chunk in chunks)
             results = []

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -443,7 +443,8 @@ class Fingerprint:
             Added support for multiprocessing
         
         .. versionadded:: 1.0.1
-            Added support for passing kwargs to the RDKitConverter
+            Added support for passing kwargs to the RDKitConverter through
+            the ``converter_kwargs`` parameter
 
         """
         if n_jobs is not None and n_jobs < 1:

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -384,12 +384,12 @@ class Fingerprint:
 
         Parameters
         ----------
-        traj : mda.coordinates.base.ProtoReader or mda.coordinates.base.FrameIteratorSliced
+        traj : MDAnalysis.coordinates.base.ProtoReader or MDAnalysis.coordinates.base.FrameIteratorSliced
             Iterate over this Universe trajectory or sliced trajectory object
             to extract the frames used for the fingerprint extraction
-        lig : mda.core.groups.AtomGroup
+        lig : MDAnalysis.core.groups.AtomGroup
             An MDAnalysis AtomGroup for the ligand
-        prot : mda.core.groups.AtomGroup
+        prot : MDAnalysis.core.groups.AtomGroup
             An MDAnalysis AtomGroup for the protein (with multiple residues)
         residues : list or "all" or None
             A list of protein residues (:class:`str`, :class:`int` or
@@ -400,7 +400,7 @@ class Fingerprint:
             automatically use protein residues that are distant of 6.0 Å or
             less from each ligand residue.
         converter_kwargs : list or None
-            List of kwargs passed to the underlying :class:`~mda.converters.RDKit.RDKitConverter`
+            List of kwargs passed to the underlying :class:`~MDAnalysis.converters.RDKit.RDKitConverter`
             from MDAnalysis: the first for the ligand, and the second for the protein
         progress : bool
             Use the `tqdm <https://tqdm.github.io/>`_ package to display a

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -597,7 +597,7 @@ class Fingerprint:
             total = len(lig_iterable)
         else:
             total = None
-        suppl = (x for x in enumerate(lig_iterable))
+        suppl = enumerate(lig_iterable)
         if residues == "all":
             residues = prot_mol.residues.keys()
 

--- a/prolif/molecule.py
+++ b/prolif/molecule.py
@@ -47,7 +47,7 @@ class Molecule(BaseRDKitMol):
         mol
 
     You can also create a Molecule directly from a
-    :class:`~MDAnalysis.core.universe.Universe`:
+    :class:`~mda.core.universe.Universe`:
 
     .. ipython:: python
         :okwarning:
@@ -85,13 +85,14 @@ class Molecule(BaseRDKitMol):
 
         Parameters
         ----------
-        obj : MDAnalysis.core.universe.Universe or MDAnalysis.core.groups.AtomGroup
+        obj : mda.core.universe.Universe or mda.core.groups.AtomGroup
             The MDAnalysis object to convert
         selection : None or str
             Apply a selection to `obj` to create an AtomGroup. Uses all atoms
             in `obj` if ``selection=None``
         **kwargs : object
-            Other arguments passed to the RDKitConverter of MDAnalysis
+            Other arguments passed to the :class:`~mda.converters.RDKit.RDKitConverter`
+            of MDAnalysis
 
         Example
         -------

--- a/prolif/molecule.py
+++ b/prolif/molecule.py
@@ -47,7 +47,7 @@ class Molecule(BaseRDKitMol):
         mol
 
     You can also create a Molecule directly from a
-    :class:`~mda.core.universe.Universe`:
+    :class:`~MDAnalysis.core.universe.Universe`:
 
     .. ipython:: python
         :okwarning:
@@ -85,13 +85,13 @@ class Molecule(BaseRDKitMol):
 
         Parameters
         ----------
-        obj : mda.core.universe.Universe or mda.core.groups.AtomGroup
+        obj : MDAnalysis.core.universe.Universe or MDAnalysis.core.groups.AtomGroup
             The MDAnalysis object to convert
         selection : None or str
             Apply a selection to `obj` to create an AtomGroup. Uses all atoms
             in `obj` if ``selection=None``
         **kwargs : object
-            Other arguments passed to the :class:`~mda.converters.RDKit.RDKitConverter`
+            Other arguments passed to the :class:`~MDAnalysis.converters.RDKit.RDKitConverter`
             of MDAnalysis
 
         Example

--- a/prolif/parallel.py
+++ b/prolif/parallel.py
@@ -10,10 +10,11 @@ from .molecule import Molecule
 def process_chunk(args):
     """Generates a fingerprint for a chunk of frame indices"""
     traj, lig, prot, chunk = args
+    lig_kwargs, prot_kwargs = converter_kwargs
     ifp = []
     for ts in traj[chunk]:
-        lig_mol = Molecule.from_mda(lig)
-        prot_mol = Molecule.from_mda(prot)
+        lig_mol = Molecule.from_mda(lig, **lig_kwargs)
+        prot_mol = Molecule.from_mda(prot, **prot_kwargs)
         data = fp.generate(lig_mol, prot_mol, residues=residues,
                            return_atoms=True)
         data["Frame"] = ts.frame
@@ -25,14 +26,15 @@ def process_chunk(args):
 
 
 def declare_shared_objs_for_chunk(fingerprint, resid_list, show_progressbar,
-                                  progress_counter):
+                                  progress_counter, rdkitconverter_kwargs):
     """Declares global objects that are available to the pool of workers for
     a trajectory"""
-    global fp, residues, display_progress, pcount
+    global fp, residues, display_progress, pcount, converter_kwargs
     fp = fingerprint
     residues = resid_list
     display_progress = show_progressbar
     pcount = progress_counter
+    converter_kwargs = rdkitconverter_kwargs
 
 
 def process_mol(args):

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,5 +1,6 @@
 from tempfile import NamedTemporaryFile
 
+import MDAnalysis as mda
 import numpy as np
 import pytest
 from pandas import DataFrame
@@ -251,3 +252,23 @@ class TestFingerprint:
         run(lig_suppl, protein_mol, n_jobs=None, progress=False)
         multi = fp.to_dataframe()
         assert serial.equals(multi)
+
+    def test_converter_kwargs_raises_error(self, fp: Fingerprint):
+        with pytest.raises(
+            ValueError,
+            match="converter_kwargs must be a list of 2 dicts"
+        ):
+            fp.run(
+                u.trajectory[0:5], ligand_ag, protein_ag, n_jobs=1, progress=False,
+                converter_kwargs=[dict(force=True)]
+            )
+    
+    @pytest.mark.parametrize("n_jobs", [1, 2])
+    def test_converter_kwargs(self, fp: Fingerprint, n_jobs: int):
+        u = mda.Universe.from_smiles("O=C=O.O=C=O")
+        lig, prot = u.atoms.fragments
+        fp.run(
+            u.trajectory, lig, prot, n_jobs=n_jobs, 
+            converter_kwargs=[dict(force=True), dict(force=True)]
+        )
+        assert fp.ifp


### PR DESCRIPTION
Fixes #57 

Allows passing parameters to the RDKitConverter of MDAnalysis from within the `run` method of the Fingerprint class:

For example, if your ligand selection is an Mg atom, you have to pass `force=True` to MDAnalysis, which can be done like so:
```python
fp.run(..., converter_kwargs=[{"force": True}, {}])
```

The second empty dict is for the protein selection, meaning that we don't pass any parameter to the converter for that selection.

TODO:
- [x] sphinx not resolving docs links to classes in MDAnalysis