### PR TITLE
rdkit-pypi replaced by rdkit on pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
         channels: conda-forge, defaults
         add-pip-as-python-dependency: true
         architecture: x64
-        mamba-version: "*"
+        use-mamba: true
+        miniforge-variant: Mambaforge
 
     - name: Check conda and pip
       run: |

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -26,7 +26,7 @@ Then simply run the following command to install the library::
 
 Alternatively, you can install ProLIF with pip instead of conda::
 
-    pip install rdkit-pypi prolif
+    pip install rdkit prolif
 
 
 .. _conda: https://docs.conda.io/projects/conda/en/latest/user-guide/index.html


### PR DESCRIPTION
Small thing, I believe rdkit now replaces rdkit-pypi for new releases.