### PR TITLE
New acceptor SMARTS for halogen bond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The SMARTS pattern for halogen bond acceptors was not allowing carbonyles and other
+  groups with double bonds to match (PR #190 by @asiomchen).
 
 ## [2.0.2] - 2024-03-01
 

--- a/prolif/interactions/interactions.py
+++ b/prolif/interactions/interactions.py
@@ -146,7 +146,7 @@ class XBAcceptor(DoubleAngle):
 
     def __init__(
         self,
-        acceptor="[#7,#8,P,S,Se,Te,a;!+{1-}][*]",
+        acceptor="[#7,#8,P,S,Se,Te,a;!+{1-}]!#[*]",
         donor="[#6,#7,Si,F,Cl,Br,I]-[Cl,Br,I,At]",
         distance=3.5,
         AXD_angle=(130, 180),

--- a/prolif/interactions/interactions.py
+++ b/prolif/interactions/interactions.py
@@ -142,6 +142,10 @@ class XBAcceptor(DoubleAngle):
         ``axd_angles`` and ``xar_angles`` parameters renamed to ``AXD_angle`` and
         ``XAR_angle``.
 
+    .. versionchanged:: 2.0.3
+        Fixed the SMARTS pattern for acceptors that was not allowing carbonyles and
+        other groups with double bonds to match.
+
     """
 
     def __init__(

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -218,6 +218,8 @@ class TestInteractions:
             ("XBAcceptor.lig_pattern", "[NH3]", 3),
             ("XBAcceptor.lig_pattern", "[NH+]C", 0),
             ("XBAcceptor.lig_pattern", "c1ccccc1", 12),
+            ("XBAcceptor.lig_pattern", "C(=O)C", 1),
+            ("XBAcceptor.lig_pattern", "C#N", 0),
             ("Cationic.lig_pattern", "[NH4+]", 1),
             ("Cationic.lig_pattern", "[Ca+2]", 1),
             ("Cationic.lig_pattern", "CC(=[NH2+])N", 2),


### PR DESCRIPTION
New default pattern for acceptor in `XBAcceptot/XBDonor` to recognize also carbonyles (and other species with double or aromatic bonds), as mentioned in #189 , below is the compassion between old and new pattern 

![obraz](https://github.com/chemosim-lab/ProLIF/assets/41703271/a7d48b9f-154b-48d3-9a78-d887f31c1eac)
