### PR TITLE
Handle edge case in `utils.py`

### DIFF
--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -151,6 +151,9 @@ def split_mol_by_residues(mol):
     -----
     Code adapted from Maciek Wójcikowski on the RDKit discussion list
     """
+    if len(GetMolFrags(mol, asMols=True, sanitizeFrags=False)) == 1:
+        # if there is only one fragment, return the molecule as a singular residue
+        return [mol]
     residues = []
     for res in SplitMolByPDBResidues(mol).values():
         for frag in GetMolFrags(res, asMols=True, sanitizeFrags=False):


### PR DESCRIPTION
* Handles an edge case in `utils.py` that would normally lead to an RDKit-caused segmentation fault upon calling `SplitMolByPDBResidues(mol)` on certain molecule (single-fragment) inputs.