### PR TITLE
Implementation of Interaction Occurence Percentage in LigNetwork

### DIFF
--- a/.github/workflows/formatting_linting.yml
+++ b/.github/workflows/formatting_linting.yml
@@ -19,12 +19,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Code formatting
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v2
         with:
-          args: "check --preview"
+          args: "format --diff"
 
       - name: Notebook formatting
         uses: psf/black@stable
         with:
           src: "docs/notebooks/"
           jupyter: true
+
+      - name: Code linting
+        uses: astral-sh/ruff-action@v2
+        with:
+          args: "check --preview --diff"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `LigNetwork` now additionally displays percentage of interaction occurence.
 - `VdWContact` now accepts a `preset` parameter to easily use different van der Waals radii values:
   one of `mdanalysis` (default), `rdkit`, or `csd`.
 - `IFP.interactions()` iterator that yields all interaction data for a given frame in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `LigNetwork` now additionally displays percentage of interaction occurence.
-- `VdWContact` now accepts a `preset` parameter to easily use different van der Waals radii values:
-  one of `mdanalysis` (default), `rdkit`, or `csd`.
+- `LigNetwork` now optionally displays the percentage of interaction occurence when
+  `show_interaction_data` is enabled. The type of data shown on both the label and
+  hover title can be modified.
+- `VdWContact` now accepts a `preset` parameter to easily use different van der Waals
+  radii values: one of `mdanalysis` (default), `rdkit`, or `csd`.
 - `IFP.interactions()` iterator that yields all interaction data for a given frame in
   a single flat structure. This makes iterating over the `fp.ifp` results a bit
   easier / less nested.

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -869,6 +869,8 @@ class Fingerprint:
         carbon: float = 0.16,
         width: str = "100%",
         height: str = "500px",
+        fontsize: int = 20,
+        show_interaction_data: bool = False,
     ):
         """Generate and display a :class:`~prolif.plotting.network.LigNetwork` plot from
         a fingerprint object that has been used to run an analysis.
@@ -910,6 +912,10 @@ class Fingerprint:
             Width of the IFrame window.
         height : str
             Height of the IFrame window.
+        fontsize: int
+            Font size used for the atoms, residues, and edge labels.
+        show_interaction_data: bool
+            Show the occurence of each interaction on the corresponding edge.
 
         Notes
         -----
@@ -924,6 +930,9 @@ class Fingerprint:
         :class:`prolif.plotting.network.LigNetwork`
 
         .. versionadded:: 2.0.0
+
+        .. versionchanged:: 2.1.0
+            Added the ``show_interaction_data`` argument and exposed the ``fontsize``.
         """
         from prolif.plotting.network import LigNetwork
 
@@ -941,7 +950,12 @@ class Fingerprint:
             rotation=rotation,
             carbon=carbon,
         )
-        return ligplot.display(width=width, height=height)
+        return ligplot.display(
+            width=width,
+            height=height,
+            fontsize=fontsize,
+            show_interaction_data=show_interaction_data,
+        )
 
     def plot_barcode(
         self,

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -475,7 +475,7 @@ class Fingerprint:
 
         converter_kwargs = converter_kwargs or ({}, {})
         if n_jobs is None:
-            n_jobs = int(os.environ.get("PROLIF_N_JOBS", 0)) or None
+            n_jobs = int(os.environ.get("PROLIF_N_JOBS", "0")) or None
         if residues == "all":
             residues = list(Molecule.from_mda(prot, **converter_kwargs[1]).residues)
         if n_jobs != 1:

--- a/prolif/parallel.py
+++ b/prolif/parallel.py
@@ -103,7 +103,7 @@ class TrajectoryPool:
     """
 
     def __init__(
-        self, n_processes, fingerprint, residues, tqdm_kwargs, rdkitconverter_kwargs,
+        self, n_processes, fingerprint, residues, tqdm_kwargs, rdkitconverter_kwargs
     ):
         self.tqdm_kwargs = tqdm_kwargs
         self.tracker = Value(c_uint32, lock=True)
@@ -142,7 +142,7 @@ class TrajectoryPool:
             lig_mol = Molecule.from_mda(lig, **cls.converter_kwargs[0])
             prot_mol = Molecule.from_mda(prot, **cls.converter_kwargs[1])
             data = cls.fp.generate(
-                lig_mol, prot_mol, residues=cls.residues, metadata=True,
+                lig_mol, prot_mol, residues=cls.residues, metadata=True
             )
             ifp[int(ts.frame)] = data
             with cls.tracker.get_lock():

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -360,7 +360,7 @@ class LigNetwork:
                             {
                                 **entry,
                                 "atoms": metadata["parent_indices"]["ligand"],
-                                "distance": metadata.get("distance", 0),
+                                "": metadata.get("distance", 0),
                             },
                         )
                 else:
@@ -580,7 +580,7 @@ class LigNetwork:
             edge = {
                 "from": origin,
                 "to": prot_res,
-                "title": f"{interaction}: {distance:.2f}Å",
+                "title": f"{interaction}: {distance:.2f}Å. Occurence: {weight * 100:.0f}%",
                 "interaction_type": self._interaction_types.get(
                     interaction,
                     interaction,

--- a/prolif/plotting/network.py
+++ b/prolif/plotting/network.py
@@ -497,10 +497,10 @@ class LigNetwork:
         for perp in (p, -p):
             for point in xyz:
                 xy = point[:2] + perp * dist
-                _id = hash(xy.tobytes())
-                nodes.append(_id)
-                self.nodes[_id] = {
-                    "id": _id,
+                id_ = hash(xy.tobytes())
+                nodes.append(id_)
+                self.nodes[id_] = {
+                    "id": id_,
                     "x": xy[0],
                     "y": xy[1],
                     "shape": "text",

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -18,8 +18,9 @@ class Dummy(Interaction):
 
 def test_interaction_base(sdf_suppl):
     interaction = Dummy()
-    _repr = repr(interaction)
-    assert _repr.startswith("<") and ".Dummy at " in _repr
+    repr_ = repr(interaction)
+    assert repr_.startswith("<")
+    assert ".Dummy at " in repr_
     assert callable(interaction)
     mol = sdf_suppl[0]
     metadata = next(interaction.detect(mol, mol))


### PR DESCRIPTION
Fixes #226 
Changes made:

- Addition of Percentage of Interaction Occurence in `LigNetwork`
- Addition of Change in `CHANGELOG.md` 


Currently I didn't make it optional with an additional button, since it is anyway only
visible when you look at the separate edge.

What I could imagine would be more like a button that would
display all the Interaction and Occurences below the nodes, but I am not sure if you would want
something like that and it would be anyway a separate PR if it would be the case :)