### PR TITLE
Minor changes to support `FrameIteratorIndices` and `Timestep` in `_run_parallel` in `fingerprint.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for `FrameIteratorIndices` as trajectories in `fp.run` (PR #246 by @wehs7661).
 - `LigNetwork` now optionally displays the percentage of interaction occurence when
   `show_interaction_data` is enabled. The type of data shown on both the label and
   hover title can be modified (PR #234 by @talagayev).

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -526,6 +526,10 @@ class Fingerprint:
                 # trajectory indices
                 frames = traj._frames
                 traj = lig.universe.trajectory
+            elif hasattr(traj, "frame"):
+                # single trajectory frame
+                frames = (traj.frame,)
+                traj = lig.universe.trajectory
         else:
             frames = range(n_frames)
         chunks = np.array_split(frames, n_chunks)

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -518,9 +518,14 @@ class Fingerprint:
         try:
             n_frames = traj.n_frames
         except AttributeError:
-            # sliced trajectory
-            frames = range(traj.start, traj.stop, traj.step)
-            traj = lig.universe.trajectory
+            if hasattr(traj, "start") and hasattr(traj, "stop") and hasattr(traj, "step"):
+                # sliced trajectory
+                frames = range(traj.start, traj.stop, traj.step)
+                traj = lig.universe.trajectory
+            elif hasattr(traj, "_frames"):
+                # trajectory indices
+                frames = traj._frames
+                traj = lig.universe.trajectory
         else:
             frames = range(n_frames)
         chunks = np.array_split(frames, n_chunks)

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -489,6 +489,9 @@ class Fingerprint:
                 n_jobs=n_jobs,
             )
 
+        # support single frame
+        if hasattr(traj, "frame"):
+            traj = (traj,)
         iterator = tqdm(traj) if progress else traj
         ifp = {}
         for ts in iterator:
@@ -518,7 +521,11 @@ class Fingerprint:
         try:
             n_frames = traj.n_frames
         except AttributeError:
-            if hasattr(traj, "start") and hasattr(traj, "stop") and hasattr(traj, "step"):
+            if (
+                hasattr(traj, "start")
+                and hasattr(traj, "stop")
+                and hasattr(traj, "step")
+            ):
                 # sliced trajectory
                 frames = range(traj.start, traj.stop, traj.step)
                 traj = lig.universe.trajectory

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,4 +1,3 @@
-import os
 import MDAnalysis as mda
 import numpy as np
 import pytest
@@ -141,12 +140,23 @@ class TestFingerprint:
         int_data = ifp[key]
         assert "Hydrophobic" in int_data
 
-    @pytest.mark.parametrize("trajectory_slice", [
-        slice(0, 1),       # test for MDAnalysis.coordinates.base.FrameIteratorSliced
-        0,                 # test for MDAnalysis.coordinates.timestep.Timestep
-        np.array([0, 2]),  # test for MDAnalysis.coordinates.base.FrameIteratorIndices
-    ])
-    def test_run(self, fp_simple, u, ligand_ag, protein_ag, trajectory_slice, tmp_path):
+    @pytest.mark.parametrize(
+        "trajectory_slice",
+        [
+            slice(0, 1),  # test for MDAnalysis.coordinates.base.FrameIteratorSliced
+            0,  # test for MDAnalysis.coordinates.timestep.Timestep
+            np.array(
+                [
+                    0,
+                    2,
+                ]
+            ),  # test for MDAnalysis.coordinates.base.FrameIteratorIndices
+        ],
+    )
+    @pytest.mark.parametrize("n_jobs", [None, 1])
+    def test_run(
+        self, fp_simple, u, ligand_ag, protein_ag, trajectory_slice, n_jobs, tmp_path
+    ):
         if isinstance(trajectory_slice, np.ndarray):
             pdb_path = tmp_path / "multi_frame.pdb"
             with mda.Writer(str(pdb_path), u.atoms.n_atoms) as W:
@@ -158,11 +168,7 @@ class TestFingerprint:
             traj = u.trajectory[trajectory_slice]
 
         fp_simple.run(
-            traj,
-            ligand_ag,
-            protein_ag,
-            residues=None,
-            progress=False,
+            traj, ligand_ag, protein_ag, residues=None, progress=False, n_jobs=n_jobs
         )
 
         assert hasattr(fp_simple, "ifp")


### PR DESCRIPTION
Hi,
Thank you for your work on ProLIF. I've made a small change to support `FrameIteratorIndices` in `_run_parallel` to better handle non-contiguous MD trajectories.

Specifically, the current implementation of `_run_parallel` in `fingerprint.py` only supports trajectories as `XTCReader` objects (where the attribute `n_frames` is available) and `MDAnalysis.coordinates.base.FrameIteratorSliced ` objects (where the attributes `start`, `stop`, and `step` are available). This PR adds support for `MDAnalysis.coordinates.base.FrameIteratorIndices`, which can be useful for one to use ProLIF to analyze certain frames from an MD trajectory (e.g., frames in a cluster, which are not necessarily contiguous). 