### PR TITLE
Enable option to export lignetwork data as a networkx graph object

### DIFF
--- a/prolif/plotting/network/lignetwork.py
+++ b/prolif/plotting/network/lignetwork.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TextIO, Union, cast
 from uuid import uuid4
 
+import networkx as nx
 import numpy as np
 import pandas as pd
 from rdkit import Chem
@@ -35,8 +36,6 @@ from prolif.ifp import IFP
 from prolif.plotting.utils import grouped_interaction_colors, metadata_iterator
 from prolif.residue import ResidueId
 from prolif.utils import requires
-
-import networkx as nx
 
 try:
     from IPython.display import Javascript, display
@@ -473,75 +472,105 @@ class LigNetwork:
             },
         )
         self._nodes[idx] = node
-    
-    def to_networkx_graph_object(self, include_ligand_bonds=True) -> nx.Graph:
+
+    def to_networkx_graph_object(self, include_ligand_bonds: bool = True) -> nx.Graph:
         """Export the interaction data directly as a NetworkX graph object.
-    
+
         Parameters
         ----------
         include_ligand_bonds : bool, default=True
         Whether to include bonds between ligand atoms in the graph
-    
+
         Returns
         -------
         nx.Graph
             A NetworkX graph representation of the ligand-protein interaction network.
         """
-        G = nx.Graph()
+        G: nx.Graph = nx.Graph()
 
         # 1. Add protein residue nodes
-        protein_residues = set(self.df.index.get_level_values('protein'))
-        for prot_res in protein_residues:
-            resname = ResidueId.from_string(prot_res).name
+        protein_residues = set(self.df.index.get_level_values("protein"))
+        for protein_residue in protein_residues:
+            resname = ResidueId.from_string(protein_residue).name
             restype = self.RESIDUE_TYPES.get(resname)
-            G.add_node(prot_res, 
-                    node_type='protein', 
-                    residue_type=restype,
-                    label=prot_res)
-    
+            G.add_node(
+                protein_residue,
+                node_type="protein",
+                residue_type=restype,
+                label=protein_residue,
+            )
+
         # 2. Add ligand atom nodes
         if include_ligand_bonds:
             for atom in self.mol.GetAtoms():
                 idx = atom.GetIdx()
-                G.add_node(idx, 
-                        node_type='ligand',
-                        symbol=atom.GetSymbol(),
-                        charge=atom.GetFormalCharge(),
-                        coords=(float(self.xyz[idx, 0]), float(self.xyz[idx, 1]), float(self.xyz[idx, 2])),
-                        label=atom.GetSymbol())
-        
+                G.add_node(
+                    idx,
+                    node_type="ligand",
+                    symbol=atom.GetSymbol(),
+                    charge=atom.GetFormalCharge(),
+                    coords=(
+                        float(self.xyz[idx, 0]),
+                        float(self.xyz[idx, 1]),
+                        float(self.xyz[idx, 2]),
+                    ),
+                    label=atom.GetSymbol(),
+                )
+
             # Add ligand bonds
             for bond in self.mol.GetBonds():
                 begin_idx = bond.GetBeginAtomIdx()
                 end_idx = bond.GetEndAtomIdx()
-                G.add_edge(begin_idx, end_idx, 
-                        edge_type='bond',
-                        bond_type=bond.GetBondType(),
-                        bond_order=bond.GetBondTypeAsDouble())
-    
+                G.add_edge(
+                    begin_idx,
+                    end_idx,
+                    edge_type="bond",
+                    bond_type=bond.GetBondType(),
+                    bond_order=bond.GetBondTypeAsDouble(),
+                )
+
         # 3. Add interaction edges
-        for (lig_res, prot_res, interaction, lig_indices), (weight, distance, components) in self.df.iterrows():
+        for idx, row in self.df.iterrows():
+            # Explicitly extract and type the index elements
+            lig_res: str = idx[0]
+            prot_res: str = idx[1]
+            interaction: str = idx[2]
+            lig_indices: tuple[int, ...] = idx[3]
+
+            # Extract row values
+            weight: float = float(row["weight"])
+            distance: float = float(row["distance"])
+            components: str = row["components"]
+
             # For interactions involving multiple ligand atoms, create edges for each
             for lig_atom_idx in lig_indices:
                 if not include_ligand_bonds and lig_atom_idx not in G:
                     # If we're not including full ligand structure, add atom nodes as needed
                     atom = self.mol.GetAtomWithIdx(lig_atom_idx)
-                    G.add_node(lig_atom_idx, 
-                            node_type='ligand',
-                            symbol=atom.GetSymbol(),
-                            coords=(float(self.xyz[lig_atom_idx, 0]), 
-                                    float(self.xyz[lig_atom_idx, 1]), 
-                                    float(self.xyz[lig_atom_idx, 2])),
-                            label=atom.GetSymbol())
-            
+                    G.add_node(
+                        lig_atom_idx,
+                        node_type="ligand",
+                        symbol=atom.GetSymbol(),
+                        charge=atom.GetFormalCharge(),
+                        coords=(
+                            float(self.xyz[lig_atom_idx, 0]),
+                            float(self.xyz[lig_atom_idx, 1]),
+                            float(self.xyz[lig_atom_idx, 2]),
+                        ),
+                        label=atom.GetSymbol(),
+                    )
+
                 # Add the interaction edge
-                G.add_edge(lig_atom_idx, prot_res, 
-                      edge_type='interaction',
-                      interaction_type=interaction,
-                      weight=float(weight),
-                      distance=float(distance),
-                      components=components)
-    
+                G.add_edge(
+                    lig_atom_idx,
+                    prot_res,
+                    edge_type="interaction",
+                    interaction_type=interaction,
+                    weight=weight,
+                    distance=distance,
+                    components=components,
+                )
+
         return G
 
     def _make_lig_edge(self, bond: Chem.Bond) -> None:

--- a/prolif/plotting/network/lignetwork.py
+++ b/prolif/plotting/network/lignetwork.py
@@ -473,13 +473,8 @@ class LigNetwork:
         )
         self._nodes[idx] = node
 
-    def to_networkx_graph_object(self, include_ligand_bonds: bool = True) -> nx.Graph:
+    def to_networkx_graph_object(self) -> nx.Graph:
         """Export the interaction data directly as a NetworkX graph object.
-
-        Parameters
-        ----------
-        include_ligand_bonds : bool, default=True
-        Whether to include bonds between ligand atoms in the graph
 
         Returns
         -------
@@ -501,33 +496,32 @@ class LigNetwork:
             )
 
         # 2. Add ligand atom nodes
-        if include_ligand_bonds:
-            for atom in self.mol.GetAtoms():
-                idx = atom.GetIdx()
-                G.add_node(
-                    idx,
-                    node_type="ligand",
-                    symbol=atom.GetSymbol(),
-                    charge=atom.GetFormalCharge(),
-                    coords=(
-                        float(self.xyz[idx, 0]),
-                        float(self.xyz[idx, 1]),
-                        float(self.xyz[idx, 2]),
-                    ),
-                    label=atom.GetSymbol(),
-                )
+        for atom in self.mol.GetAtoms():
+            idx = atom.GetIdx()
+            G.add_node(
+                idx,
+                node_type="ligand",
+                symbol=atom.GetSymbol(),
+                charge=atom.GetFormalCharge(),
+                coords=(
+                    float(self.xyz[idx, 0]),
+                    float(self.xyz[idx, 1]),
+                    float(self.xyz[idx, 2]),
+                ),
+                label=atom.GetSymbol(),
+            )
 
-            # Add ligand bonds
-            for bond in self.mol.GetBonds():
-                begin_idx = bond.GetBeginAtomIdx()
-                end_idx = bond.GetEndAtomIdx()
-                G.add_edge(
-                    begin_idx,
-                    end_idx,
-                    edge_type="bond",
-                    bond_type=bond.GetBondType(),
-                    bond_order=bond.GetBondTypeAsDouble(),
-                )
+        # Add ligand bonds
+        for bond in self.mol.GetBonds():
+            begin_idx = bond.GetBeginAtomIdx()
+            end_idx = bond.GetEndAtomIdx()
+            G.add_edge(
+                begin_idx,
+                end_idx,
+                edge_type="bond",
+                bond_type=bond.GetBondType(),
+                bond_order=bond.GetBondTypeAsDouble(),
+            )
 
         # 3. Add interaction edges
         for idx, row in self.df.iterrows():
@@ -544,23 +538,6 @@ class LigNetwork:
 
             # For interactions involving multiple ligand atoms, create edges for each
             for lig_atom_idx in lig_indices:
-                if not include_ligand_bonds and lig_atom_idx not in G:
-                    # If we're not including full ligand structure, add atom nodes as needed
-                    atom = self.mol.GetAtomWithIdx(lig_atom_idx)
-                    G.add_node(
-                        lig_atom_idx,
-                        node_type="ligand",
-                        symbol=atom.GetSymbol(),
-                        charge=atom.GetFormalCharge(),
-                        coords=(
-                            float(self.xyz[lig_atom_idx, 0]),
-                            float(self.xyz[lig_atom_idx, 1]),
-                            float(self.xyz[lig_atom_idx, 2]),
-                        ),
-                        label=atom.GetSymbol(),
-                    )
-
-                # Add the interaction edge
                 G.add_edge(
                     lig_atom_idx,
                     prot_res,

--- a/prolif/plotting/network/lignetwork.py
+++ b/prolif/plotting/network/lignetwork.py
@@ -473,7 +473,7 @@ class LigNetwork:
         )
         self._nodes[idx] = node
 
-    def to_networkx_graph_object(self) -> nx.Graph:
+    def to_networkx(self) -> nx.Graph:
         """Export the interaction data directly as a NetworkX graph object.
 
         Returns

--- a/tests/plotting/test_nx_graph_export.py
+++ b/tests/plotting/test_nx_graph_export.py
@@ -9,7 +9,7 @@ from prolif.plotting.network.lignetwork import LigNetwork
 
 
 @pytest.fixture
-def simple_ligand_mol() -> Chem.rdchem.Mol:
+def simple_ligand_mol() -> Chem.Mol:
     """Create a simple ligand molecule (benzene) for testing"""
     mol = Chem.MolFromSmiles("c1ccccc1")
     mol = Chem.AddHs(mol)
@@ -54,17 +54,17 @@ def simple_interaction_df() -> pd.DataFrame:
 
 @pytest.fixture
 def lignetwork_obj(
-    simple_ligand_mol: Chem.rdchem.Mol, simple_interaction_df: pd.DataFrame
+    simple_ligand_mol: Chem.Mol, simple_interaction_df: pd.DataFrame
 ) -> LigNetwork:
     """Create a LigNetwork object for testing"""
     return LigNetwork(simple_interaction_df, simple_ligand_mol)
 
 
 def test_to_networkx_graph(
-    lignetwork_obj: LigNetwork, simple_ligand_mol: Chem.rdchem.Mol
+    lignetwork_obj: LigNetwork, simple_ligand_mol: Chem.Mol
 ) -> None:
-    """Test to_networkx_graph_object"""
-    G = lignetwork_obj.to_networkx_graph_object()
+    """Test to_networkx"""
+    G = lignetwork_obj.to_networkx()
 
     # Check that the graph has the correct number of nodes
     # All atoms + 2 protein residues
@@ -97,7 +97,7 @@ def test_interaction_edge_attributes(
     lignetwork_obj: LigNetwork, simple_interaction_df: pd.DataFrame
 ) -> None:
     """Test that interaction edges have the correct attributes"""
-    G = lignetwork_obj.to_networkx_graph_object()
+    G = lignetwork_obj.to_networkx()
 
     # Track interactions found in the graph
     interaction_types = set(simple_interaction_df.index.get_level_values("interaction"))
@@ -156,7 +156,7 @@ def test_interaction_edge_attributes(
 
 def test_node_attributes(lignetwork_obj: LigNetwork) -> None:
     """Test that nodes have the correct attributes"""
-    G = lignetwork_obj.to_networkx_graph_object()
+    G = lignetwork_obj.to_networkx()
 
     # Check ligand atom attributes
     for i in range(lignetwork_obj.mol.GetNumAtoms()):
@@ -182,7 +182,7 @@ def test_empty_interaction_df() -> None:
 
     # Create the LigNetwork and convert to NetworkX
     network = LigNetwork(df, mol)
-    G = network.to_networkx_graph_object()
+    G = network.to_networkx()
 
     # Should only have ligand atoms, no protein nodes, no interaction edges
     assert len(G.nodes) == mol.GetNumAtoms()

--- a/tests/plotting/test_nx_graph_export.py
+++ b/tests/plotting/test_nx_graph_export.py
@@ -1,0 +1,229 @@
+from typing import Any, cast
+
+import pandas as pd
+import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from prolif.plotting.network.lignetwork import LigNetwork
+
+
+@pytest.fixture
+def simple_ligand_mol() -> Chem.rdchem.Mol:
+    """Create a simple ligand molecule (benzene) for testing"""
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    mol = Chem.AddHs(mol)
+    AllChem.EmbedMolecule(mol, randomSeed=42)  # type: ignore
+    return mol
+
+
+@pytest.fixture
+def simple_interaction_df() -> pd.DataFrame:
+    """Create a simple DataFrame with ligand-protein interactions"""
+    # Create a simple dataframe with interactions
+    data = [
+        # ligand, protein, interaction, atoms, weight, distance, components
+        ["LIG:1", "PRO:A:100", "Hydrophobic", (0, 1), 1.0, 3.5, "ligand_protein"],
+        ["LIG:1", "PRO:A:101", "HBAcceptor", (2,), 0.8, 2.9, "ligand_protein"],
+        [
+            "LIG:1",
+            "PRO:A:102",
+            "PiStacking",
+            (0, 1, 2, 3, 4, 5),
+            0.9,
+            4.0,
+            "ligand_protein",
+        ],
+    ]
+
+    # Create the multi-level index
+    idx = pd.MultiIndex.from_tuples(
+        [(row[0], row[1], row[2], row[3]) for row in data],
+        names=["ligand", "protein", "interaction", "atoms"],
+    )
+
+    # Create DataFrame with weight and distance columns
+    df = pd.DataFrame(
+        [(row[4], row[5], row[6]) for row in data],
+        index=idx,
+        columns=["weight", "distance", "components"],
+    )
+
+    return df
+
+
+@pytest.fixture
+def lignetwork_obj(
+    simple_ligand_mol: Chem.rdchem.Mol, simple_interaction_df: pd.DataFrame
+) -> LigNetwork:
+    """Create a LigNetwork object for testing"""
+    return LigNetwork(simple_interaction_df, simple_ligand_mol)
+
+
+def test_to_networkx_graph_with_bonds(
+    lignetwork_obj: LigNetwork, simple_ligand_mol: Chem.rdchem.Mol
+) -> None:
+    """Test to_networkx_graph_object with include_ligand_bonds=True (default)"""
+    G = lignetwork_obj.to_networkx_graph_object()
+
+    # Check that the graph has the correct number of nodes
+    # All atoms + 3 protein residues
+    expected_nodes = simple_ligand_mol.GetNumAtoms() + 3
+    assert len(G.nodes) == expected_nodes
+
+    # Check for ligand atoms
+    for i in range(simple_ligand_mol.GetNumAtoms()):
+        assert i in G.nodes
+        assert G.nodes[i]["node_type"] == "ligand"
+
+    # Check for protein residues
+    expected_residues = ["PRO:A:100", "PRO:A:101", "PRO:A:102"]
+    for res in expected_residues:
+        assert res in G.nodes
+        assert G.nodes[res]["node_type"] == "protein"
+        assert G.nodes[res]["label"] == res
+
+    # Check for bonds
+    bond_edges = 0
+    for u, v, data in G.edges(data=True):
+        if data.get("edge_type") == "bond":
+            bond_edges += 1
+
+    # There should be the same number of bonds as in the molecule
+    assert bond_edges == simple_ligand_mol.GetNumBonds()
+
+
+def test_to_networkx_graph_without_bonds(
+    lignetwork_obj: LigNetwork, simple_interaction_df: pd.DataFrame
+) -> None:
+    """Test to_networkx_graph_object with include_ligand_bonds=False"""
+    G = lignetwork_obj.to_networkx_graph_object(include_ligand_bonds=False)
+
+    # Get unique atoms involved in interactions
+    interaction_atoms = set()
+    for idx in simple_interaction_df.index:
+        interaction_atoms.update(idx[3])
+
+    # Protein residues
+    protein_residues = set(simple_interaction_df.index.get_level_values("protein"))
+
+    # Check that only interacting atoms and protein residues are present
+    assert len(G.nodes) == len(interaction_atoms) + len(protein_residues)
+
+    # Check all expected nodes are present
+    for atom in interaction_atoms:
+        assert atom in G.nodes
+        assert G.nodes[atom]["node_type"] == "ligand"
+
+    for residue in protein_residues:
+        assert residue in G.nodes
+        assert G.nodes[residue]["node_type"] == "protein"
+
+    # No bonds should be present
+    bond_edges = 0
+    for u, v, data in G.edges(data=True):
+        if data.get("edge_type") == "bond":
+            bond_edges += 1
+    assert bond_edges == 0
+
+
+def test_interaction_edge_attributes(
+    lignetwork_obj: LigNetwork, simple_interaction_df: pd.DataFrame
+) -> None:
+    """Test that interaction edges have the correct attributes"""
+    G = lignetwork_obj.to_networkx_graph_object()
+
+    # Track interactions found in the graph
+    interaction_types = set(simple_interaction_df.index.get_level_values("interaction"))
+    found_interactions = dict.fromkeys(interaction_types, False)
+
+    # Check all edges for interactions
+    interaction_count = 0
+    for u, v, data in G.edges(data=True):
+        if data.get("edge_type") == "interaction":
+            interaction_count += 1
+
+            # One end should be a string (residue ID) and one an int (atom index)
+            assert (isinstance(u, int) and isinstance(v, str)) or (
+                isinstance(u, str) and isinstance(v, int)
+            )
+
+            # Get the atom index and residue ID
+            atom_idx = u if isinstance(u, int) else v
+            residue = v if isinstance(v, str) else u
+
+            # Mark interaction as found if matches
+            interaction_type = data.get("interaction_type")
+            if interaction_type in found_interactions:
+                found_interactions[interaction_type] = True
+
+                # Find matching row in dataframe - use .xs() instead of .loc[] for type safety
+                try:
+                    matching_rows = simple_interaction_df.xs(
+                        (slice(None), residue, interaction_type),
+                        level=cast(Any, ["ligand", "protein", "interaction"]),
+                        drop_level=False,
+                    )
+                except KeyError:
+                    matching_rows = pd.DataFrame()
+
+                # At least one row should match
+                assert not matching_rows.empty
+
+                # For at least one row, the atom should be part of the interaction
+                atom_in_interaction = False
+                for idx, _ in matching_rows.iterrows():
+                    # Get the atoms from the multi-index - it's the 'atoms' level (4th position)
+                    atoms = cast(
+                        tuple[int, ...], idx[-1] if isinstance(idx, tuple) else idx
+                    )
+                    if atom_idx in atoms:
+                        atom_in_interaction = True
+                        break
+
+                assert atom_in_interaction
+
+    # All interactions should have been found
+    for interaction, found in found_interactions.items():
+        assert found, f"Interaction {interaction} not found in the graph"
+
+
+def test_node_attributes(lignetwork_obj: LigNetwork) -> None:
+    """Test that nodes have the correct attributes"""
+    G = lignetwork_obj.to_networkx_graph_object()
+
+    # Check ligand atom attributes
+    for i in range(lignetwork_obj.mol.GetNumAtoms()):
+        node = G.nodes[i]
+        assert node["node_type"] == "ligand"
+        assert node["symbol"] == lignetwork_obj.mol.GetAtomWithIdx(i).GetSymbol()
+        assert "coords" in node
+        assert len(node["coords"]) == 3  # 3D coordinates
+
+
+def test_empty_interaction_df() -> None:
+    """Test with an empty interactions DataFrame"""
+    # Create a small molecule
+    mol = Chem.MolFromSmiles("CC")
+    mol = Chem.AddHs(mol)
+    AllChem.EmbedMolecule(mol)  # type: ignore
+
+    # Create an empty DataFrame with the right structure
+    idx = pd.MultiIndex.from_tuples(
+        [], names=["ligand", "protein", "interaction", "atoms"]
+    )
+    df = pd.DataFrame([], index=idx, columns=["weight", "distance", "components"])
+
+    # Create the LigNetwork and convert to NetworkX
+    network = LigNetwork(df, mol)
+    G = network.to_networkx_graph_object()
+
+    # Should only have ligand atoms, no protein nodes, no interaction edges
+    assert len(G.nodes) == mol.GetNumAtoms()
+    assert (
+        len([n for n, d in G.nodes(data=True) if d.get("node_type") == "protein"]) == 0
+    )
+    assert (
+        len([e for e in G.edges(data=True) if e[2].get("edge_type") == "interaction"])
+        == 0
+    )


### PR DESCRIPTION
adds support for exporting ligand–protein interaction data as a NetworkX graph object.