### PR TITLE
Unpin numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = [
 ]
 dependencies = [
     "pandas>=1.1.0",
-    "numpy>=1.13.3,<2",
+    "numpy>=1.13.3",
     "scipy>=1.3.0",
     "mdanalysis>=2.2.0,<3; python_version<'3.13'",
     "mdanalysis>=2.7.0,<3; python_version>='3.13'",


### PR DESCRIPTION
Numpy was pinned to `numpy<2` in ea08ac125d7cf9f2b6b133da348deae9bfbe534b with the comment  `# remove numpy<2 when MDAnalysis 2.8.0 is released` which it now has. 