### PR TITLE
Fix `ResidueId.from_string` to support underscore chain IDs

### DIFF
--- a/prolif/residue.py
+++ b/prolif/residue.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from prolif.typeshed import ResidueKey
 
 _RE_RESID = re.compile(
-    r"(TIP[234]|T[234]P|H2O|[0-9][A-Z]{2}|[A-Z ]+)?(\d*)\.?([A-Z\d]{1,2})?"
+    r"(TIP[234]|T[234]P|H2O|[0-9][A-Z]{2}|[A-Z ]+)?(\d*)\.?([A-Z_\d]{1,2})?"
 )
 
 

--- a/tests/test_residues.py
+++ b/tests/test_residues.py
@@ -133,6 +133,7 @@ class TestResidueId:
             ("K  123.A", ("K", 123, "A")),
             ("MN123.A", ("MN", 123, "A")),
             ("MN 123.A", ("MN", 123, "A")),
+            ("HOH7._", ("HOH", 7, "_"))
         ],
     )
     def test_from_string(


### PR DESCRIPTION
### Summary
This PR fixes an issue #298. In `ResidueId.from_string` where residue strings with an underscore (`_`) as the chain ID (e.g. water residues like `HOH7._`) were not parsed correctly.

### Example
Before:
```python
protein_mol["HOH7._"]
>>> KeyError: ResidueId(HOH, 7, None)
```
because in group 3 (ie.- `([A-Z\d]{1,2})` ) there is no condition to validate `_` like inputs :
```python
 r"(TIP[234]|T[234]P|H2O|[0-9][A-Z]{2}|[A-Z ]+)?(\d*)\.?([A-Z\d]{1,2})?"
```

Changes i have made:
1. added `_` to group 3 - changed `([A-Z\d]{1,2})`  --> `([A-Z_\d]{1,2})` 
```python
 r"(TIP[234]|T[234]P|H2O|[0-9][A-Z]{2}|[A-Z ]+)?(\d*)\.?([A-Z_\d]{1,2})?"
```
2. added test to verify correction  `("HOH7._", ("HOH", 7, "_"))`

```python
( [         .
            .
            ("HOH7._", ("HOH", 7, "_"))
        ],
    )
    def test_from_string(
        self, resid_str: str, expected: tuple[str, int, str | None]
    ) -> None:
```