### PR TITLE
[Document] MDAnalysis residue handling in WaterBridge

### DIFF
--- a/prolif/interactions/water_bridge.py
+++ b/prolif/interactions/water_bridge.py
@@ -7,6 +7,8 @@ for analyzing water-mediated interactions. It does so by generating fingerprints
 ligand-water, water-protein, and water-water interactions. The results are then
 combined to identify water-bridged interactions using a graph-based approach.
 
+.. versionadded:: 2.1.0
+
 Notes
 -----
 WaterBridge relies on MDAnalysis residue handling to uniquely identify
@@ -15,13 +17,11 @@ individual water molecules.
 Due to the 4-digit limitation of residue numbering in the PDB format,
 multiple water molecules may appear to share the same residue number
 (e.g., ``resid 1917``). MDAnalysis internally guarantees unique residue
-identities by offsetting residue indices when parsing PDB files.
+identities when parsing PDB files (e.g., by offsetting residue indices).
 
 As a result, WaterBridge correctly treats each water molecule as a
 distinct residue, and users do not need to manually deduplicate water
-residues when using MDAnalysis-supported formats.
-
-.. versionadded:: 2.1.0
+residues when using MDAnalysis-supported formats
 
 """
 

--- a/prolif/interactions/water_bridge.py
+++ b/prolif/interactions/water_bridge.py
@@ -7,6 +7,20 @@ for analyzing water-mediated interactions. It does so by generating fingerprints
 ligand-water, water-protein, and water-water interactions. The results are then
 combined to identify water-bridged interactions using a graph-based approach.
 
+Notes
+-----
+WaterBridge relies on MDAnalysis residue handling to uniquely identify
+individual water molecules.
+
+Due to the 4-digit limitation of residue numbering in the PDB format,
+multiple water molecules may appear to share the same residue number
+(e.g., ``resid 1917``). MDAnalysis internally guarantees unique residue
+identities by offsetting residue indices when parsing PDB files.
+
+As a result, WaterBridge correctly treats each water molecule as a
+distinct residue, and users do not need to manually deduplicate water
+residues when using MDAnalysis-supported formats.
+
 .. versionadded:: 2.1.0
 
 """


### PR DESCRIPTION
### Summary
This addresses the confusion discussed in #299, where users were concerned about duplicated water residues affecting WaterBridge detection. The underlying behavior was confirmed to be correct, but the assumption was undocumented.

By clarifying this in the module docstring, users can better understand:
* why duplicated resid values may appear in raw PDB files
* how MDAnalysis resolves this internally
* and why WaterBridge remains correct without manual deduplication.

### Changes
Added description in `water_bridge.py`

```text
Water-mediated interactions --- :mod:`prolif.interactions.water_bridge`
=======================================================================
.
.
.. versionadded:: 2.1.0

Notes
-----
WaterBridge relies on MDAnalysis residue handling to uniquely identify
individual water molecules.

Due to the 4-digit limitation of residue numbering in the PDB format,
multiple water molecules may appear to share the same residue number
(e.g., ``resid 1917``). MDAnalysis internally guarantees unique residue
identities when parsing PDB files (e.g., by offsetting residue indices).

As a result, WaterBridge correctly treats each water molecule as a
distinct residue, and users do not need to manually deduplicate water
residues when using MDAnalysis-supported formats.

```

happy to modify pr if required 