### PR TITLE
Fix Issue #70: prevent RDKit sanitization from altering protein backbone functional groups

### DIFF
--- a/prolif/molecule.py
+++ b/prolif/molecule.py
@@ -369,7 +369,12 @@ class pdbqt_supplier(Sequence[Molecule]):
         mol = rwmol.GetMol()
         # sanitize
         mol.UpdatePropertyCache()
-        Chem.SanitizeMol(mol)
+        Chem.SanitizeMol(
+            mol,
+            sanitizeOps=Chem.SanitizeFlags.SANITIZE_ALL
+            ^ Chem.SanitizeFlags.SANITIZE_KEKULIZE
+        )
+
         return mol
 
     def __len__(self) -> int:


### PR DESCRIPTION
### Problem
Backbone standardization using RDKit could modify the nature of the functional groups #70
### Solution
The changes I made prevents RDKit from kekulizing
 protein structures by disabling the kekulization step during sanitization.
I am attaching my approach that I used in this PR.

![chart2](https://github.com/user-attachments/assets/07e27272-9d1a-4834-9c4e-9ce6986b1484)








