### PR TITLE
Feature/Add JAX-accelerated interaction fingerprinting

### DIFF
--- a/prolif/interactions/__init__.py
+++ b/prolif/interactions/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 from prolif.interactions.base import (
     BasePiStacking,
     Distance,

--- a/prolif/interactions/_jax/README.md
+++ b/prolif/interactions/_jax/README.md
@@ -1,0 +1,308 @@
+# JAX-Accelerated Interaction Fingerprinting
+
+This module provides GPU and CPU acceleration for protein-ligand interaction
+fingerprinting using JAX. It achieves significant speedups over the standard
+ProLIF implementation by vectorizing geometry calculations across trajectory
+frames.
+
+## Performance
+
+Benchmarks on a typical protein-ligand system (40 ligand atoms, 20 residues):
+
+| Backend | Speedup vs ProLIF | Notes |
+|---------|-------------------|-------|
+| CPU (JAX) | 80-100x | After JIT warmup |
+| GPU (JAX) | 100-200x | After JIT warmup |
+
+The speedup comes from:
+- Frame-batching: geometry is vectorized across all trajectory frames
+- JIT compilation: JAX compiles optimized kernels for the specific system size
+- SMARTS matching done once: pattern matching is structure-based, not coordinate-based
+
+## Requirements
+
+```
+jax
+jaxlib
+```
+
+For GPU acceleration:
+```
+jax[cuda12]  # or appropriate CUDA version
+```
+
+## Quick Start
+
+### Trajectory Analysis
+
+```python
+import MDAnalysis as mda
+from prolif.interactions._jax import analyze_trajectory
+
+# Load trajectory
+u = mda.Universe("topology.pdb", "trajectory.xtc")
+
+# Run analysis (CPU)
+results = analyze_trajectory(
+    u,
+    ligand_selection="resname LIG",
+    protein_selection="protein",
+)
+
+# Run analysis (GPU)
+results = analyze_trajectory(
+    u,
+    ligand_selection="resname LIG",
+    protein_selection="protein",
+    device="gpu",
+)
+
+# Access results
+print(f"Analyzed {results.n_frames} frames, {results.n_residues} residues")
+
+# Get hydrogen bond donor counts per residue
+for rid, count in zip(results.residue_ids, results.interactions["HBDonor"].sum(axis=0)):
+    if count > 0:
+        print(f"{rid}: {count} HB donor contacts")
+```
+
+### Single Frame Analysis
+
+```python
+import prolif
+from prolif.interactions._jax import analyze_frame
+
+# Build molecules
+lig_mol = prolif.Molecule.from_mda(ligand_atomgroup)
+prot_mol = prolif.Molecule.from_mda(protein_atomgroup)
+
+# Analyze single frame
+results = analyze_frame(lig_mol, prot_mol)
+
+# Results: {ResidueId: {"HBDonor": True, "Hydrophobic": False, ...}}
+for rid, interactions in results.items():
+    active = [k for k, v in interactions.items() if v]
+    if active:
+        print(f"{rid}: {', '.join(active)}")
+```
+
+## API Reference
+
+### analyze_trajectory
+
+```python
+analyze_trajectory(
+    universe,
+    ligand_selection="resname LIG",
+    protein_selection="protein",
+    *,
+    cutoff=6.0,
+    max_frames=None,
+    device="cpu",
+    chunk_size=None,
+    residue_mode="first",
+    scan_stride=1,
+) -> InteractionResult
+```
+
+**Parameters:**
+
+- `universe`: MDAnalysis Universe with trajectory loaded
+- `ligand_selection`: MDAnalysis selection string for the ligand
+- `protein_selection`: MDAnalysis selection string for the protein
+- `cutoff`: Distance cutoff (Angstroms) for selecting residues near the ligand
+- `max_frames`: Maximum number of frames to process. If None, process all.
+- `device`: `"cpu"` or `"gpu"`. GPU provides significant speedup for large trajectories.
+- `chunk_size`: Frames per GPU batch. If None, auto-calculated based on
+  available GPU memory. Ignored for CPU.
+- `residue_mode`: Residue selection strategy (see Residue Selection Modes below).
+  `"first"` (default) or `"all"`.
+- `scan_stride`: Frame stride for the `"all"` mode pre-scan. Default 1 scans
+  every frame. Higher values reduce scan time. Ignored for `"first"` mode.
+
+**Returns:** `InteractionResult` object containing:
+
+- `interactions`: Dict mapping interaction name to (n_frames, n_residues) boolean array
+- `residue_ids`: List of ProLIF ResidueId objects
+- `n_frames`: Number of frames processed
+- `n_residues`: Number of residues evaluated
+
+### InteractionResult
+
+The result container provides several convenience methods:
+
+```python
+# Convert to pandas DataFrame with MultiIndex columns
+df = results.to_dataframe()
+
+# Get list of (frame_idx, residue_id, interaction_name) tuples
+contacts = results.get_contacts()
+contacts = results.get_contacts("HBAcceptor")  # filter by interaction
+
+# Count interactions per residue across all frames
+by_residue = results.count_by_residue()
+# Returns: {ResidueId: {"HBDonor": 42, "Hydrophobic": 156, ...}}
+
+# Count interactions per frame across all residues
+by_frame = results.count_by_frame()
+# Returns: {0: {"HBDonor": 3, ...}, 1: {"HBDonor": 2, ...}, ...}
+```
+
+### analyze_frame
+
+```python
+analyze_frame(
+    ligand,
+    protein,
+    *,
+    cutoff=6.0,
+) -> dict[ResidueId, dict[str, bool]]
+```
+
+**Parameters:**
+
+- `ligand`: ProLIF Molecule for the ligand
+- `protein`: ProLIF Molecule for the protein
+- `cutoff`: Distance cutoff for residue selection
+
+**Returns:** Dict mapping ResidueId to interaction results.
+
+## Residue Selection Modes
+
+The `residue_mode` parameter controls which protein residues are evaluated:
+
+### first (default)
+
+Selects residues within the cutoff distance in the first frame only.
+
+- Fast setup with no trajectory pre-scan
+- Minimal memory footprint (smallest residue set)
+- Best for stable, bound systems where the ligand remains in the binding site
+
+### all
+
+Pre-scans the entire trajectory to find any residue that enters the cutoff
+at any frame, then evaluates all of them across all frames.
+
+- Captures late-arriving contacts for drifting or unbinding ligands
+- Uses MDAnalysis `capped_distance` for efficient, PBC-aware scanning
+- Fixed residue set enables stable JAX array shapes (no JIT retracing)
+- Early frames return False for residues not yet in contact (correct behavior)
+
+```python
+results = analyze_trajectory(
+    u,
+    ligand_selection="resname LIG",
+    protein_selection="protein",
+    residue_mode="all",
+    scan_stride=1,
+)
+```
+
+The scan logs the residue count comparison:
+```
+Residue scan complete: 45 residues within 6.0 A across trajectory (first frame: 23 residues)
+```
+
+For very long trajectories, increase `scan_stride` to reduce scan time at the
+cost of potentially missing briefly-contacting residues.
+
+## Supported Interactions
+
+The module evaluates nine interaction types:
+
+| Interaction | Description |
+|-------------|-------------|
+| Hydrophobic | Hydrophobic contacts within 4.5 A |
+| Cationic | Cation-anion salt bridges (ligand cation) |
+| Anionic | Cation-anion salt bridges (ligand anion) |
+| VdWContact | Van der Waals contacts based on atomic radii |
+| HBAcceptor | Hydrogen bonds (ligand as acceptor) |
+| HBDonor | Hydrogen bonds (ligand as donor) |
+| PiStacking | Pi-pi stacking (face-to-face and edge-to-face) |
+| CationPi | Cation-pi interactions (ligand cation, protein ring) |
+| PiCation | Cation-pi interactions (ligand ring, protein cation) |
+
+## Architecture
+
+The acceleration is achieved through a frame-batching strategy:
+
+1. **SMARTS Matching (Once)**: Pattern matching for functional groups is performed
+   once on the molecular graph. This identifies donor/acceptor atoms, rings,
+   cations, etc. These indices are fixed across all frames since connectivity
+   does not change during MD.
+
+2. **Coordinate Extraction**: Trajectory coordinates are extracted into dense
+   arrays with shapes:
+   - Ligand: (n_frames, n_ligand_atoms, 3)
+   - Residues: (n_frames, n_residues, max_atoms_per_residue, 3)
+
+3. **Vectorized Geometry**: Distance and angle calculations are vectorized
+   across all frames using JAX's `vmap`. This enables efficient parallelization
+   on both CPU (via XLA) and GPU (via CUDA).
+
+4. **Memory Management**: For GPU execution, the trajectory is automatically
+   chunked to fit within available GPU memory. Chunk size is calculated based
+   on the number of atoms and available memory.
+
+## Low-Level API
+
+For advanced use cases, the low-level primitives are also exported:
+
+```python
+from prolif.interactions._jax import (
+    # Geometry functions
+    pairwise_distances_frames,
+    hbacceptor_frames,
+    hbdonor_frames,
+    pistacking_frames,
+    cationpi_frames,
+    xbacceptor_frames,
+    xbdonor_frames,
+
+    # Index building
+    build_actor_masks,
+    build_angle_indices,
+    build_ring_cation_indices,
+    build_vdw_radii,
+
+    # Device management
+    prepare_for_device,
+    get_gpu_device,
+    get_gpu_memory_info,
+    calculate_chunk_size,
+
+    # Core computation
+    has_interactions_frames,
+    chunked_has_interactions_frames,
+)
+```
+
+## Limitations
+
+1. **JIT Warmup**: The first call incurs JIT compilation overhead (typically 1-5
+   seconds). Subsequent calls with the same array shapes are fast.
+
+2. **Metal Interactions**: MetalDonor and MetalAcceptor interactions are matched
+   via SMARTS but use simple distance criteria (no specialized metal geometry).
+
+3. **Halogen Bonds**: XBAcceptor and XBDonor are implemented but not included in
+   the default nine-interaction set returned by `analyze_trajectory`.
+
+4. **Residue Selection Trade-offs**: With `residue_mode="first"` (default),
+   residues that move into proximity later in the trajectory are not evaluated.
+   Use `residue_mode="all"` to capture late-arriving contacts at the cost of
+   slower setup and larger memory footprint.
+
+## Checking JAX Availability
+
+```python
+from prolif.interactions._jax import JAX_AVAILABLE
+
+if JAX_AVAILABLE:
+    from prolif.interactions._jax import analyze_trajectory
+    # Use JAX-accelerated path
+else:
+    # Fall back to standard ProLIF
+    pass
+```

--- a/prolif/interactions/_jax/README.md
+++ b/prolif/interactions/_jax/README.md
@@ -1,94 +1,49 @@
-# JAX-Accelerated Interaction Fingerprinting
+# JAX Interaction Fingerprinting
 
-This module provides GPU and CPU acceleration for protein-ligand interaction
-fingerprinting using JAX. It achieves significant speedups over the standard
-ProLIF implementation by vectorizing geometry calculations across trajectory
-frames.
-
-## Performance
-
-Benchmarks on a typical protein-ligand system (40 ligand atoms, 20 residues):
-
-| Backend | Speedup vs ProLIF | Notes |
-|---------|-------------------|-------|
-| CPU (JAX) | 80-100x | After JIT warmup |
-| GPU (JAX) | 100-200x | After JIT warmup |
-
-The speedup comes from:
-- Frame-batching: geometry is vectorized across all trajectory frames
-- JIT compilation: JAX compiles optimized kernels for the specific system size
-- SMARTS matching done once: pattern matching is structure-based, not coordinate-based
+JAX-backed interaction fingerprinting for ProLIF trajectory and single-frame workflows.
 
 ## Requirements
 
-```
-jax
-jaxlib
+- `jax`
+- `jaxlib`
+
+CPU install:
+
+```bash
+pip install "jax[cpu]"
 ```
 
-For GPU acceleration:
-```
-jax[cuda12]  # or appropriate CUDA version
-```
+GPU install depends on your CUDA setup. Use the JAX install guide for the correct wheel.
 
 ## Quick Start
 
-### Trajectory Analysis
+### Trajectory analysis
 
 ```python
 import MDAnalysis as mda
 from prolif.interactions._jax import analyze_trajectory
 
-# Load trajectory
 u = mda.Universe("topology.pdb", "trajectory.xtc")
 
-# Run analysis (CPU)
 results = analyze_trajectory(
     u,
     ligand_selection="resname LIG",
     protein_selection="protein",
+    device="cpu",  # or "gpu"
 )
 
-# Run analysis (GPU)
-results = analyze_trajectory(
-    u,
-    ligand_selection="resname LIG",
-    protein_selection="protein",
-    device="gpu",
-)
-
-# Access results
-print(f"Analyzed {results.n_frames} frames, {results.n_residues} residues")
-
-# Get hydrogen bond donor counts per residue
-for rid, count in zip(results.residue_ids, results.interactions["HBDonor"].sum(axis=0)):
-    if count > 0:
-        print(f"{rid}: {count} HB donor contacts")
+df = results.to_dataframe()
 ```
 
-### Single Frame Analysis
+### Single frame analysis
 
 ```python
-import prolif
 from prolif.interactions._jax import analyze_frame
 
-# Build molecules
-lig_mol = prolif.Molecule.from_mda(ligand_atomgroup)
-prot_mol = prolif.Molecule.from_mda(protein_atomgroup)
-
-# Analyze single frame
-results = analyze_frame(lig_mol, prot_mol)
-
-# Results: {ResidueId: {"HBDonor": True, "Hydrophobic": False, ...}}
-for rid, interactions in results.items():
-    active = [k for k, v in interactions.items() if v]
-    if active:
-        print(f"{rid}: {', '.join(active)}")
+frame_result = analyze_frame(ligand_mol, protein_mol, cutoff=6.0)
 ```
 
-## API Reference
-
-### analyze_trajectory
+## Main API
 
 ```python
 analyze_trajectory(
@@ -100,209 +55,47 @@ analyze_trajectory(
     max_frames=None,
     device="cpu",
     chunk_size=None,
-    residue_mode="first",
-    scan_stride=1,
-) -> InteractionResult
-```
-
-**Parameters:**
-
-- `universe`: MDAnalysis Universe with trajectory loaded
-- `ligand_selection`: MDAnalysis selection string for the ligand
-- `protein_selection`: MDAnalysis selection string for the protein
-- `cutoff`: Distance cutoff (Angstroms) for selecting residues near the ligand
-- `max_frames`: Maximum number of frames to process. If None, process all.
-- `device`: `"cpu"` or `"gpu"`. GPU provides significant speedup for large trajectories.
-- `chunk_size`: Frames per GPU batch. If None, auto-calculated based on
-  available GPU memory. Ignored for CPU.
-- `residue_mode`: Residue selection strategy (see Residue Selection Modes below).
-  `"first"` (default) or `"all"`.
-- `scan_stride`: Frame stride for the `"all"` mode pre-scan. Default 1 scans
-  every frame. Higher values reduce scan time. Ignored for `"first"` mode.
-
-**Returns:** `InteractionResult` object containing:
-
-- `interactions`: Dict mapping interaction name to (n_frames, n_residues) boolean array
-- `residue_ids`: List of ProLIF ResidueId objects
-- `n_frames`: Number of frames processed
-- `n_residues`: Number of residues evaluated
-
-### InteractionResult
-
-The result container provides several convenience methods:
-
-```python
-# Convert to pandas DataFrame with MultiIndex columns
-df = results.to_dataframe()
-
-# Get list of (frame_idx, residue_id, interaction_name) tuples
-contacts = results.get_contacts()
-contacts = results.get_contacts("HBAcceptor")  # filter by interaction
-
-# Count interactions per residue across all frames
-by_residue = results.count_by_residue()
-# Returns: {ResidueId: {"HBDonor": 42, "Hydrophobic": 156, ...}}
-
-# Count interactions per frame across all residues
-by_frame = results.count_by_frame()
-# Returns: {0: {"HBDonor": 3, ...}, 1: {"HBDonor": 2, ...}, ...}
-```
-
-### analyze_frame
-
-```python
-analyze_frame(
-    ligand,
-    protein,
-    *,
-    cutoff=6.0,
-) -> dict[ResidueId, dict[str, bool]]
-```
-
-**Parameters:**
-
-- `ligand`: ProLIF Molecule for the ligand
-- `protein`: ProLIF Molecule for the protein
-- `cutoff`: Distance cutoff for residue selection
-
-**Returns:** Dict mapping ResidueId to interaction results.
-
-## Residue Selection Modes
-
-The `residue_mode` parameter controls which protein residues are evaluated:
-
-### first (default)
-
-Selects residues within the cutoff distance in the first frame only.
-
-- Fast setup with no trajectory pre-scan
-- Minimal memory footprint (smallest residue set)
-- Best for stable, bound systems where the ligand remains in the binding site
-
-### all
-
-Pre-scans the entire trajectory to find any residue that enters the cutoff
-at any frame, then evaluates all of them across all frames.
-
-- Captures late-arriving contacts for drifting or unbinding ligands
-- Uses MDAnalysis `capped_distance` for efficient, PBC-aware scanning
-- Fixed residue set enables stable JAX array shapes (no JIT retracing)
-- Early frames return False for residues not yet in contact (correct behavior)
-
-```python
-results = analyze_trajectory(
-    u,
-    ligand_selection="resname LIG",
-    protein_selection="protein",
     residue_mode="all",
     scan_stride=1,
 )
 ```
 
-The scan logs the residue count comparison:
-```
-Residue scan complete: 45 residues within 6.0 A across trajectory (first frame: 23 residues)
-```
+Key parameters:
 
-For very long trajectories, increase `scan_stride` to reduce scan time at the
-cost of potentially missing briefly-contacting residues.
+- `device`: `"cpu"` or `"gpu"`
+- `chunk_size`: frames per batch; if `None`, CPU uses `256`, GPU uses auto size capped at `256`
+- `residue_mode`:
+  - `"all"`: select residues seen near ligand across trajectory
+  - `"first"`: select residues from first frame only
+- `scan_stride`: only used with `residue_mode="all"`
 
-## Supported Interactions
+Returns `InteractionResult` with:
 
-The module evaluates nine interaction types:
+- `interactions`: `dict[str, np.ndarray]` of shape `(n_frames, n_residues)`
+- `residue_ids`
+- `n_frames`
+- `n_residues`
 
-| Interaction | Description |
-|-------------|-------------|
-| Hydrophobic | Hydrophobic contacts within 4.5 A |
-| Cationic | Cation-anion salt bridges (ligand cation) |
-| Anionic | Cation-anion salt bridges (ligand anion) |
-| VdWContact | Van der Waals contacts based on atomic radii |
-| HBAcceptor | Hydrogen bonds (ligand as acceptor) |
-| HBDonor | Hydrogen bonds (ligand as donor) |
-| PiStacking | Pi-pi stacking (face-to-face and edge-to-face) |
-| CationPi | Cation-pi interactions (ligand cation, protein ring) |
-| PiCation | Cation-pi interactions (ligand ring, protein cation) |
+## Interaction Types
 
-## Architecture
+The high-level trajectory API returns these nine interaction maps:
 
-The acceleration is achieved through a frame-batching strategy:
+- `Hydrophobic`
+- `Cationic`
+- `Anionic`
+- `VdWContact`
+- `HBAcceptor`
+- `HBDonor`
+- `PiStacking`
+- `CationPi`
+- `PiCation`
 
-1. **SMARTS Matching (Once)**: Pattern matching for functional groups is performed
-   once on the molecular graph. This identifies donor/acceptor atoms, rings,
-   cations, etc. These indices are fixed across all frames since connectivity
-   does not change during MD.
+## Notes
 
-2. **Coordinate Extraction**: Trajectory coordinates are extracted into dense
-   arrays with shapes:
-   - Ligand: (n_frames, n_ligand_atoms, 3)
-   - Residues: (n_frames, n_residues, max_atoms_per_residue, 3)
-
-3. **Vectorized Geometry**: Distance and angle calculations are vectorized
-   across all frames using JAX's `vmap`. This enables efficient parallelization
-   on both CPU (via XLA) and GPU (via CUDA).
-
-4. **Memory Management**: For GPU execution, the trajectory is automatically
-   chunked to fit within available GPU memory. Chunk size is calculated based
-   on the number of atoms and available memory.
-
-## Low-Level API
-
-For advanced use cases, the low-level primitives are also exported:
-
-```python
-from prolif.interactions._jax import (
-    # Geometry functions
-    pairwise_distances_frames,
-    hbacceptor_frames,
-    hbdonor_frames,
-    pistacking_frames,
-    cationpi_frames,
-    xbacceptor_frames,
-    xbdonor_frames,
-
-    # Index building
-    build_actor_masks,
-    build_angle_indices,
-    build_ring_cation_indices,
-    build_vdw_radii,
-
-    # Device management
-    prepare_for_device,
-    get_gpu_device,
-    get_gpu_memory_info,
-    calculate_chunk_size,
-
-    # Core computation
-    has_interactions_frames,
-    chunked_has_interactions_frames,
-)
-```
-
-## Limitations
-
-1. **JIT Warmup**: The first call incurs JIT compilation overhead (typically 1-5
-   seconds). Subsequent calls with the same array shapes are fast.
-
-2. **Metal Interactions**: MetalDonor and MetalAcceptor interactions are matched
-   via SMARTS but use simple distance criteria (no specialized metal geometry).
-
-3. **Halogen Bonds**: XBAcceptor and XBDonor are implemented but not included in
-   the default nine-interaction set returned by `analyze_trajectory`.
-
-4. **Residue Selection Trade-offs**: With `residue_mode="first"` (default),
-   residues that move into proximity later in the trajectory are not evaluated.
-   Use `residue_mode="all"` to capture late-arriving contacts at the cost of
-   slower setup and larger memory footprint.
-
-## Checking JAX Availability
+- First call may be slower due to JIT compilation.
+- If GPU execution fails due memory pressure, set a smaller `chunk_size` (for example `128`, `64`, or `32`).
+- Check availability with:
 
 ```python
 from prolif.interactions._jax import JAX_AVAILABLE
-
-if JAX_AVAILABLE:
-    from prolif.interactions._jax import analyze_trajectory
-    # Use JAX-accelerated path
-else:
-    # Fall back to standard ProLIF
-    pass
 ```

--- a/prolif/interactions/_jax/__init__.py
+++ b/prolif/interactions/_jax/__init__.py
@@ -11,67 +11,65 @@ Low-level primitives (for custom pipelines):
 
 try:
     import jax
+
     JAX_AVAILABLE = True
 except ImportError:
     JAX_AVAILABLE = False
 
 if JAX_AVAILABLE:
     # High-level API (recommended entry points)
-    from .api import analyze_trajectory, analyze_frame, InteractionResult
-
-    # Low-level primitives
-    from .primitives import pairwise_distances
-    from .integration import compute_distances_batch, has_interaction_batch
+    from .api import InteractionResult, analyze_frame, analyze_trajectory
     from .framebatch import (
-        pairwise_distances_frames,
-        hbacceptor_frames,
-        hbdonor_frames,
         build_actor_masks,
         build_angle_indices,
         build_ring_cation_indices,
         build_vdw_radii,
-        has_interactions_frames,
-        xbacceptor_frames,
-        xbdonor_frames,
+        calculate_chunk_size,
         cationpi_frames,
-        pistacking_frames,
-        prepare_for_device,
+        chunked_has_interactions_frames,
+        estimate_memory_per_frame,
         get_gpu_device,
         get_gpu_memory_info,
-        estimate_memory_per_frame,
-        calculate_chunk_size,
-        chunked_has_interactions_frames,
+        has_interactions_frames,
+        hbacceptor_frames,
+        hbdonor_frames,
+        pairwise_distances_frames,
+        pistacking_frames,
+        prepare_for_device,
+        xbacceptor_frames,
+        xbdonor_frames,
     )
+    from .integration import compute_distances_batch, has_interaction_batch
+
+    # Low-level primitives
+    from .primitives import pairwise_distances
 
     __all__ = [
-        # Availability flag
         "JAX_AVAILABLE",
-        # High-level API
-        "analyze_trajectory",
-        "analyze_frame",
         "InteractionResult",
-        # Low-level primitives
-        "pairwise_distances",
-        "compute_distances_batch",
-        "has_interaction_batch",
-        "pairwise_distances_frames",
-        "hbacceptor_frames",
-        "hbdonor_frames",
+        "analyze_frame",
+        "analyze_trajectory",
         "build_actor_masks",
         "build_angle_indices",
         "build_ring_cation_indices",
         "build_vdw_radii",
-        "has_interactions_frames",
-        "xbacceptor_frames",
-        "xbdonor_frames",
+        "calculate_chunk_size",
         "cationpi_frames",
-        "pistacking_frames",
-        "prepare_for_device",
+        "chunked_has_interactions_frames",
+        "compute_distances_batch",
+        "estimate_memory_per_frame",
         "get_gpu_device",
         "get_gpu_memory_info",
-        "estimate_memory_per_frame",
-        "calculate_chunk_size",
-        "chunked_has_interactions_frames",
+        "has_interaction_batch",
+        "has_interactions_frames",
+        "hbacceptor_frames",
+        "hbdonor_frames",
+        "pairwise_distances",
+        "pairwise_distances_frames",
+        "pistacking_frames",
+        "prepare_for_device",
+        "xbacceptor_frames",
+        "xbdonor_frames",
     ]
 else:
     __all__ = ["JAX_AVAILABLE"]

--- a/prolif/interactions/_jax/__init__.py
+++ b/prolif/interactions/_jax/__init__.py
@@ -1,0 +1,77 @@
+"""
+JAX-accelerated helpers for ProLIF.
+
+High-level API (recommended):
+- analyze_trajectory: Process full MD trajectories with automatic GPU/chunking
+- analyze_frame: Single-frame analysis matching ProLIF Molecule API
+
+Low-level primitives (for custom pipelines):
+- pairwise_distances, has_interactions_frames, etc.
+"""
+
+try:
+    import jax
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+
+if JAX_AVAILABLE:
+    # High-level API (recommended entry points)
+    from .api import analyze_trajectory, analyze_frame, InteractionResult
+
+    # Low-level primitives
+    from .primitives import pairwise_distances
+    from .integration import compute_distances_batch, has_interaction_batch
+    from .framebatch import (
+        pairwise_distances_frames,
+        hbacceptor_frames,
+        hbdonor_frames,
+        build_actor_masks,
+        build_angle_indices,
+        build_ring_cation_indices,
+        build_vdw_radii,
+        has_interactions_frames,
+        xbacceptor_frames,
+        xbdonor_frames,
+        cationpi_frames,
+        pistacking_frames,
+        prepare_for_device,
+        get_gpu_device,
+        get_gpu_memory_info,
+        estimate_memory_per_frame,
+        calculate_chunk_size,
+        chunked_has_interactions_frames,
+    )
+
+    __all__ = [
+        # Availability flag
+        "JAX_AVAILABLE",
+        # High-level API
+        "analyze_trajectory",
+        "analyze_frame",
+        "InteractionResult",
+        # Low-level primitives
+        "pairwise_distances",
+        "compute_distances_batch",
+        "has_interaction_batch",
+        "pairwise_distances_frames",
+        "hbacceptor_frames",
+        "hbdonor_frames",
+        "build_actor_masks",
+        "build_angle_indices",
+        "build_ring_cation_indices",
+        "build_vdw_radii",
+        "has_interactions_frames",
+        "xbacceptor_frames",
+        "xbdonor_frames",
+        "cationpi_frames",
+        "pistacking_frames",
+        "prepare_for_device",
+        "get_gpu_device",
+        "get_gpu_memory_info",
+        "estimate_memory_per_frame",
+        "calculate_chunk_size",
+        "chunked_has_interactions_frames",
+    ]
+else:
+    __all__ = ["JAX_AVAILABLE"]

--- a/prolif/interactions/_jax/__init__.py
+++ b/prolif/interactions/_jax/__init__.py
@@ -1,13 +1,4 @@
-"""
-JAX-accelerated helpers for ProLIF.
-
-High-level API (recommended):
-- analyze_trajectory: Process full MD trajectories with automatic GPU/chunking
-- analyze_frame: Single-frame analysis matching ProLIF Molecule API
-
-Low-level primitives (for custom pipelines):
-- pairwise_distances, has_interactions_frames, etc.
-"""
+"""Public JAX interaction API exports."""
 
 try:
     import jax

--- a/prolif/interactions/_jax/api.py
+++ b/prolif/interactions/_jax/api.py
@@ -1,26 +1,13 @@
-"""
-High-level API for JAX-accelerated interaction fingerprinting.
-
-This module provides a simple, user-friendly interface that hides the complexity
-of coordinate extraction, SMARTS mask building, device placement, and chunking.
-
-Example usage:
-    >>> from prolif.interactions._jax import analyze_trajectory
-    >>> results = analyze_trajectory(
-    ...     universe,
-    ...     ligand_selection="resname LIG",
-    ...     protein_selection="protein",
-    ...     device="gpu",
-    ... )
-    >>> print(results.interactions["HBDonor"].sum())  # total HB donor interactions
-"""
+"""High-level API for JAX interaction fingerprinting."""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from MDAnalysis.lib.distances import capped_distance
@@ -36,10 +23,22 @@ from .framebatch import (
     build_ring_cation_indices,
     build_vdw_radii,
     calculate_chunk_size,
-    chunked_has_interactions_frames,
     has_interactions_frames,
     prepare_for_device,
 )
+
+INTERACTION_NAMES = [
+    "Hydrophobic",
+    "Cationic",
+    "Anionic",
+    "VdWContact",
+    "HBAcceptor",
+    "HBDonor",
+    "PiStacking",
+    "CationPi",
+    "PiCation",
+]
+GPU_AUTO_CHUNK_CAP = 256
 
 
 @dataclass
@@ -188,18 +187,86 @@ def _build_trajectory_frames(
     return lig_f, res_f, res_valid_mask
 
 
+def _resolve_frame_count(trajectory: Any, max_frames: int | None = None) -> int:
+    """Return number of frames to process after applying max_frames."""
+    total = len(trajectory)
+    return total if not max_frames or max_frames <= 0 else min(total, int(max_frames))
+
+
+def _build_residue_valid_mask(residue_ags: list[Any]) -> tuple[jnp.ndarray, int]:
+    """Build (R, M) valid-atom mask and return max atoms per residue."""
+    max_m = max((r.n_atoms for r in residue_ags), default=0)
+    rows = []
+    for r in residue_ags:
+        m = r.n_atoms
+        row = np.zeros((max_m,), dtype=bool)
+        row[:m] = True
+        rows.append(row)
+    mask = jnp.array(np.stack(rows, axis=0) if rows else np.zeros((0, 0), dtype=bool))
+    return mask, max_m
+
+
+def _iter_trajectory_chunks(
+    universe: Any,
+    lig_ag: Any,
+    residue_ags: list[Any],
+    max_m: int,
+    chunk_size: int,
+    max_frames: int | None = None,
+) -> Iterator[tuple[jnp.ndarray, jnp.ndarray, int]]:
+    """Yield streamed coordinate chunks as (lig_chunk, res_chunk, n_frames_chunk)."""
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be > 0, got {chunk_size}")
+
+    F = _resolve_frame_count(universe.trajectory, max_frames=max_frames)
+    N = lig_ag.n_atoms
+
+    lig_frames: list[np.ndarray] = []
+    res_frames: list[np.ndarray] = []
+
+    for _ in universe.trajectory[:F]:
+        lig_frames.append(np.array(lig_ag.positions, dtype=float).reshape(N, 3))
+
+        row_list = []
+        for r in residue_ags:
+            coords = np.array(r.positions, dtype=float)
+            m = coords.shape[0]
+            if m < max_m:
+                pad = np.zeros((max_m - m, 3), dtype=float)
+                coords = np.concatenate([coords, pad], axis=0)
+            row_list.append(coords)
+
+        if row_list:
+            res_frames.append(np.stack(row_list, axis=0))
+        else:
+            res_frames.append(np.zeros((0, max_m, 3), dtype=float))
+
+        if len(lig_frames) == chunk_size:
+            yield (
+                jnp.array(np.stack(lig_frames, axis=0)),
+                jnp.array(np.stack(res_frames, axis=0)),
+                len(lig_frames),
+            )
+            lig_frames.clear()
+            res_frames.clear()
+
+    if lig_frames:
+        yield (
+            jnp.array(np.stack(lig_frames, axis=0)),
+            jnp.array(np.stack(res_frames, axis=0)),
+            len(lig_frames),
+        )
+
+
 def _get_residue_ags_from_ids(
     prot_ag: Any,
     residue_ids: list[ResidueId],
     use_segid: bool = False,
 ) -> list[Any]:
-    """Map ProLIF ResidueIds to MDAnalysis AtomGroups via direct residue lookup.
-
-    Builds a lookup from (resname, resid, segid) to AtomGroup once, then
-    matches each ResidueId directly without string-based selection.
-    """
+    """Return protein AtomGroups matching the provided residue identifiers."""
     by_key: dict[tuple[str, int, str | None], Any] = {}
     for r in prot_ag.residues:
+        chain: str | None
         if use_segid:
             chain = str(int(r.segindex))
         else:
@@ -207,7 +274,7 @@ def _get_residue_ags_from_ids(
                 chain = str(r.atoms[0].chainID).strip() or None
             except Exception:
                 chain = None
-        by_key[(r.resname, r.resid, chain)] = r.atoms
+        by_key[r.resname, r.resid, chain] = r.atoms
 
     result: list[Any] = []
     for rid in residue_ids:
@@ -228,23 +295,7 @@ def _scan_residues_all_frames(
     stride: int = 1,
     use_segid: bool = False,
 ) -> set[tuple[str, int, str | None]]:
-    """Scan all trajectory frames to find residues within cutoff of the ligand.
-
-    Uses MDAnalysis capped_distance for efficient, PBC-aware neighbor searching.
-    Returns a set of (resname, resid, segid) tuples identifying unique residues
-    that come within the cutoff distance of any ligand atom at any frame.
-
-    Args:
-        universe: MDAnalysis Universe with trajectory loaded.
-        lig_ag: Ligand AtomGroup.
-        prot_ag: Protein AtomGroup.
-        cutoff: Distance cutoff in Angstroms.
-        max_frames: Maximum frames to scan. If None, scan all frames.
-        stride: Frame stride for scanning. Default 1 scans every frame.
-
-    Returns:
-        Set of (resname, resid, segid) tuples for residues found within cutoff.
-    """
+    """Return residue keys that contact the ligand within the distance cutoff."""
     F_total = len(universe.trajectory)
     F = F_total if not max_frames or max_frames <= 0 else min(F_total, int(max_frames))
 
@@ -272,6 +323,7 @@ def _scan_residues_all_frames(
         nearby_atoms = prot_ag.atoms[prot_indices]
 
         for res in nearby_atoms.residues:
+            chain: str | None
             if use_segid:
                 chain = str(int(res.segindex))
             else:
@@ -288,18 +340,7 @@ def _residue_keys_to_ids(
     residue_keys: set[tuple[str, int, str | None]],
     prot_mol: Any,
 ) -> list[ResidueId]:
-    """Convert (resname, resid, segid) tuples to ProLIF ResidueId objects.
-
-    Matches residue keys against the protein molecule to retrieve the
-    corresponding ProLIF ResidueId objects, preserving the chain information.
-
-    Args:
-        residue_keys: Set of (resname, resid, segid) tuples.
-        prot_mol: ProLIF Molecule for the protein.
-
-    Returns:
-        List of matching ProLIF ResidueId objects.
-    """
+    """Return residue IDs for the given residue keys."""
     by_key = {(rid.name, rid.number, rid.chain): rid for rid in prot_mol.residues}
     matched_ids: list[ResidueId] = []
     for key in sorted(
@@ -327,10 +368,6 @@ def analyze_trajectory(
 ) -> InteractionResult:
     """Compute interaction fingerprints for all frames in a trajectory.
 
-    This is the main entry point for JAX-accelerated interaction analysis.
-    It handles all the complexity of coordinate extraction, SMARTS matching,
-    device placement, and memory-safe chunking.
-
     Args:
         universe: MDAnalysis Universe with trajectory loaded.
         ligand_selection: MDAnalysis selection string for the ligand.
@@ -338,8 +375,8 @@ def analyze_trajectory(
         cutoff: Distance cutoff (Angstroms) for selecting residues near the ligand.
         max_frames: Maximum number of frames to process. If None, process all.
         device: 'cpu' or 'gpu'. GPU provides significant speedup for large trajectories.
-        chunk_size: Frames per GPU batch. If None, auto-calculated based on
-            available GPU memory. Ignored for CPU.
+        chunk_size: Frames per streamed batch. If None, GPU uses an auto-size
+            capped at 256 frames and CPU uses 256 frames.
         residue_mode: Residue selection strategy. Default is 'all'.
             'all': Pre-scan all frames to find any residue that enters the
                 cutoff at any point. Correct for drifting or unbinding ligands.
@@ -356,24 +393,6 @@ def analyze_trajectory(
         InteractionResult containing boolean arrays for each interaction type:
         Hydrophobic, Cationic, Anionic, VdWContact, HBAcceptor, HBDonor,
         PiStacking, CationPi, PiCation.
-
-    Example:
-        >>> import MDAnalysis as mda
-        >>> from prolif.interactions._jax import analyze_trajectory
-        >>>
-        >>> u = mda.Universe("topology.pdb", "trajectory.xtc")
-        >>> results = analyze_trajectory(
-        ...     u,
-        ...     ligand_selection="resname LIG",
-        ...     protein_selection="protein",
-        ...     device="gpu",
-        ...     residue_mode="all",
-        ... )
-        >>>
-        >>> hb_counts = results.interactions["HBDonor"].sum(axis=0)
-        >>> for rid, count in zip(results.residue_ids, hb_counts):
-        ...     if count > 0:
-        ...         print(f"{rid}: {count} HB donor contacts")
     """
     logger = logging.getLogger(__name__)
 
@@ -432,28 +451,22 @@ def analyze_trajectory(
     if not residues:
         return InteractionResult(
             interactions={
-                name: np.zeros((0, 0), dtype=bool)
-                for name in [
-                    "Hydrophobic",
-                    "Cationic",
-                    "Anionic",
-                    "VdWContact",
-                    "HBAcceptor",
-                    "HBDonor",
-                    "PiStacking",
-                    "CationPi",
-                    "PiCation",
-                ]
+                name: np.zeros((0, 0), dtype=bool) for name in INTERACTION_NAMES
             },
             residue_ids=[],
             n_frames=0,
             n_residues=0,
         )
 
-    lig_f, res_f, res_valid_mask = _build_trajectory_frames(
-        universe, lig_ag, residue_ags, max_frames=max_frames
-    )
-    F = int(lig_f.shape[0])
+    res_valid_mask, max_m = _build_residue_valid_mask(residue_ags)
+    N = lig_ag.n_atoms
+    R = len(residue_ags)
+    if chunk_size is None:
+        if device == "gpu":
+            chunk_size = min(calculate_chunk_size(N, R, max_m), GPU_AUTO_CHUNK_CAP)
+        else:
+            chunk_size = 256
+    chunk_size = int(max(1, chunk_size))
 
     lig_res_for_smarts = next(iter(lig_mol.residues.values()))
     lig_masks, res_actor_masks = build_actor_masks(lig_mol, residues)
@@ -464,8 +477,8 @@ def analyze_trajectory(
     )
 
     (
-        lig_f,
-        res_f,
+        _,
+        _,
         res_valid_mask,
         lig_masks,
         res_actor_masks,
@@ -473,8 +486,8 @@ def analyze_trajectory(
         ring_idx,
         vdw_radii,
     ) = prepare_for_device(
-        lig_f,
-        res_f,
+        jnp.zeros((0, N, 3), dtype=float),
+        jnp.zeros((0, R, max_m, 3), dtype=float),
         res_valid_mask,
         lig_masks,
         res_actor_masks,
@@ -484,42 +497,68 @@ def analyze_trajectory(
         device=device,
     )
 
+    gpu_dev = None
     if device == "gpu":
-        N = int(lig_f.shape[1])
-        R = int(res_f.shape[1])
-        M = int(res_f.shape[2])
-        if chunk_size is None:
-            chunk_size = calculate_chunk_size(N, R, M)
-        results = chunked_has_interactions_frames(
-            lig_f,
-            res_f,
-            res_valid_mask,
-            lig_masks,
-            res_actor_masks,
-            angle_idx,
-            ring_idx,
-            vdw_radii,
-            chunk_size=chunk_size,
-        )
-    else:
-        results = has_interactions_frames(
-            lig_f,
-            res_f,
-            res_valid_mask,
-            lig_masks,
-            res_actor_masks,
-            angle_idx,
-            ring_idx,
-            vdw_radii,
-            vicinity_cutoff=cutoff,
-        )
+        try:
+            gpus = jax.devices("gpu")
+            gpu_dev = gpus[0] if gpus else None
+        except Exception:
+            gpu_dev = None
 
-    np_results = {k: np.asarray(v) for k, v in results.items()}
+    chunk_results: list[dict[str, np.ndarray]] = []
+    total_frames = 0
+
+    for lig_chunk, res_chunk, n_chunk_frames in _iter_trajectory_chunks(
+        universe,
+        lig_ag,
+        residue_ags,
+        max_m=max_m,
+        chunk_size=chunk_size,
+        max_frames=max_frames,
+    ):
+        try:
+            lig_chunk_dev = lig_chunk
+            res_chunk_dev = res_chunk
+            if gpu_dev is not None:
+                lig_chunk_dev = jax.device_put(lig_chunk, device=gpu_dev)
+                res_chunk_dev = jax.device_put(res_chunk, device=gpu_dev)
+
+            chunk_result = has_interactions_frames(
+                lig_chunk_dev,
+                res_chunk_dev,
+                res_valid_mask,
+                lig_masks,
+                res_actor_masks,
+                angle_idx,
+                ring_idx,
+                vdw_radii,
+                vicinity_cutoff=cutoff,
+            )
+        except Exception as exc:
+            if device == "gpu":
+                raise RuntimeError(
+                    f"JAX chunk evaluation failed at chunk_size={chunk_size}. "
+                    "Try a smaller chunk_size (for example: 128, 64, or 32)."
+                ) from exc
+            raise
+        chunk_result = jax.device_get(chunk_result)
+        chunk_results.append({k: np.asarray(v) for k, v in chunk_result.items()})
+        total_frames += n_chunk_frames
+
+    if chunk_results:
+        np_results = {
+            name: np.concatenate([chunk[name] for chunk in chunk_results], axis=0)
+            for name in INTERACTION_NAMES
+        }
+    else:
+        np_results = {
+            name: np.zeros((0, len(residues)), dtype=bool) for name in INTERACTION_NAMES
+        }
 
     return InteractionResult(
         interactions=np_results,
         residue_ids=list(residue_ids),
-        n_frames=F,
+        n_frames=total_frames,
         n_residues=len(residues),
     )
 
@@ -530,10 +569,7 @@ def analyze_frame(
     *,
     cutoff: float = 6.0,
 ) -> dict[ResidueId, dict[str, bool]]:
-    """Compute interactions for a single frame (ProLIF Molecule objects).
-
-    This is a convenience function for single-frame analysis that accepts
-    ProLIF Molecule objects directly, matching the ProLIF API style.
+    """Compute interactions for a single ligand/protein frame.
 
     Args:
         ligand: ProLIF Molecule for the ligand.

--- a/prolif/interactions/_jax/api.py
+++ b/prolif/interactions/_jax/api.py
@@ -1,0 +1,542 @@
+"""
+High-level API for JAX-accelerated interaction fingerprinting.
+
+This module provides a simple, user-friendly interface that hides the complexity
+of coordinate extraction, SMARTS mask building, device placement, and chunking.
+
+Example usage:
+    >>> from prolif.interactions._jax import analyze_trajectory
+    >>> results = analyze_trajectory(
+    ...     universe,
+    ...     ligand_selection="resname LIG",
+    ...     protein_selection="protein",
+    ...     device="gpu",
+    ... )
+    >>> print(results.interactions["HBDonor"].sum())  # total HB donor interactions
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import jax.numpy as jnp
+import numpy as np
+import prolif
+from MDAnalysis.lib.distances import capped_distance
+from prolif import ResidueId
+from prolif.utils import get_residues_near_ligand
+
+from .framebatch import (
+    build_actor_masks,
+    build_angle_indices,
+    build_angle_indices_rdkit,
+    build_ring_cation_indices,
+    build_vdw_radii,
+    calculate_chunk_size,
+    chunked_has_interactions_frames,
+    has_interactions_frames,
+    prepare_for_device,
+)
+
+if TYPE_CHECKING:
+    import MDAnalysis as mda
+
+
+@dataclass
+class InteractionResult:
+    """Container for JAX-accelerated interaction fingerprint results.
+
+    Attributes:
+        interactions: Mapping from interaction name to (F, R) boolean array.
+            True indicates the interaction is present for that frame/residue pair.
+        residue_ids: List of ProLIF ResidueId objects for each residue column.
+        n_frames: Number of frames processed.
+        n_residues: Number of residues evaluated.
+        interaction_names: List of interaction names in evaluation order.
+    """
+
+    interactions: dict[str, np.ndarray]
+    residue_ids: list["ResidueId"]
+    n_frames: int
+    n_residues: int
+    interaction_names: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not self.interaction_names:
+            self.interaction_names = list(self.interactions.keys())
+
+    def to_dataframe(self):
+        """Convert results to a pandas DataFrame with MultiIndex columns.
+
+        Returns a DataFrame with shape (n_frames, n_residues * n_interactions)
+        using a MultiIndex of (residue_id, interaction_name) for columns.
+        Columns are ordered as: (res0, int0), (res0, int1), ..., (res1, int0), ...
+        """
+        import pandas as pd
+
+        columns = pd.MultiIndex.from_product(
+            [self.residue_ids, self.interaction_names],
+            names=["residue", "interaction"],
+        )
+
+        reshaped = np.zeros((self.n_frames, self.n_residues * len(self.interaction_names)), dtype=bool)
+        for r_i in range(self.n_residues):
+            for i_i, name in enumerate(self.interaction_names):
+                col_idx = r_i * len(self.interaction_names) + i_i
+                reshaped[:, col_idx] = self.interactions[name][:, r_i]
+
+        return pd.DataFrame(reshaped, columns=columns)
+
+    def get_contacts(self, interaction: str | None = None) -> list[tuple[int, "ResidueId", str]]:
+        """Get list of (frame_idx, residue_id, interaction_name) tuples where contacts occur.
+
+        Args:
+            interaction: If specified, filter to only this interaction type.
+
+        Returns:
+            List of tuples identifying each detected contact.
+        """
+        contacts = []
+        names = [interaction] if interaction else self.interaction_names
+        for name in names:
+            if name not in self.interactions:
+                continue
+            arr = self.interactions[name]
+            for f_i, r_i in np.argwhere(arr):
+                contacts.append((int(f_i), self.residue_ids[int(r_i)], name))
+        return contacts
+
+    def count_by_residue(self) -> dict["ResidueId", dict[str, int]]:
+        """Count interactions per residue across all frames.
+
+        Returns:
+            Mapping from residue_id to {interaction_name: count}.
+        """
+        result = {}
+        for r_i, rid in enumerate(self.residue_ids):
+            result[rid] = {}
+            for name in self.interaction_names:
+                result[rid][name] = int(self.interactions[name][:, r_i].sum())
+        return result
+
+    def count_by_frame(self) -> dict[int, dict[str, int]]:
+        """Count interactions per frame across all residues.
+
+        Returns:
+            Mapping from frame_index to {interaction_name: count}.
+        """
+        result = {}
+        for f_i in range(self.n_frames):
+            result[f_i] = {}
+            for name in self.interaction_names:
+                result[f_i][name] = int(self.interactions[name][f_i, :].sum())
+        return result
+
+
+def _build_trajectory_frames(u, lig_ag, residue_ags, max_frames: int | None = None):
+    """Build per-frame coordinate arrays from MDAnalysis trajectory."""
+    F_total = len(u.trajectory)
+    F = F_total if not max_frames or max_frames <= 0 else min(F_total, int(max_frames))
+
+    N = lig_ag.n_atoms
+    max_m = max((r.n_atoms for r in residue_ags), default=0)
+
+    lig_frames = []
+    res_frames = []
+    res_masks = []
+    for r in residue_ags:
+        m = r.n_atoms
+        rm = np.zeros((max_m,), dtype=bool)
+        rm[:m] = True
+        res_masks.append(rm)
+    res_valid_mask = jnp.array(
+        np.stack(res_masks, axis=0) if res_masks else np.zeros((0, 0), dtype=bool)
+    )
+
+    for _ in u.trajectory[:F]:
+        lig_frames.append(np.array(lig_ag.positions, dtype=float).reshape(N, 3))
+        row_list = []
+        for r in residue_ags:
+            coords = np.array(r.positions, dtype=float)
+            m = coords.shape[0]
+            if m < max_m:
+                pad = np.zeros((max_m - m, 3), dtype=float)
+                coords = np.concatenate([coords, pad], axis=0)
+            row_list.append(coords)
+        res_frames.append(
+            np.stack(row_list, axis=0) if row_list else np.zeros((0, 0, 3), dtype=float)
+        )
+
+    lig_f = jnp.array(
+        np.stack(lig_frames, axis=0) if lig_frames else np.zeros((0, N, 3), dtype=float)
+    )
+    res_f = jnp.array(
+        np.stack(res_frames, axis=0)
+        if res_frames
+        else np.zeros((0, len(residue_ags), max_m, 3), dtype=float)
+    )
+    return lig_f, res_f, res_valid_mask
+
+
+def _get_residue_ags_from_ids(prot_ag, residue_ids):
+    """Map ProLIF ResidueIds to MDAnalysis AtomGroups via direct residue lookup.
+
+    Builds a lookup from (resname, resid, segid) to AtomGroup once, then
+    matches each ResidueId directly without string-based selection.
+    """
+    by_key = {(r.resname, r.resid, r.segid): r.atoms for r in prot_ag.residues}
+    by_resname_resid = {}
+    for r in prot_ag.residues:
+        by_resname_resid.setdefault((r.resname, r.resid), r.atoms)
+
+    result = []
+    for rid in residue_ids:
+        key = (rid.name or "", rid.number, rid.chain or "")
+        ag = by_key.get(key) or by_resname_resid.get((rid.name or "", rid.number))
+        if ag is None:
+            raise ValueError(f"Could not find residue {rid} in protein AtomGroup")
+        result.append(ag)
+    return result
+
+
+def _scan_residues_all_frames(
+    universe,
+    lig_ag,
+    prot_ag,
+    cutoff: float,
+    max_frames: int | None = None,
+    stride: int = 1,
+) -> set[tuple[str, int, str]]:
+    """Scan all trajectory frames to find residues within cutoff of the ligand.
+
+    Uses MDAnalysis capped_distance for efficient, PBC-aware neighbor searching.
+    Returns a set of (resname, resid, segid) tuples identifying unique residues
+    that come within the cutoff distance of any ligand atom at any frame.
+
+    Args:
+        universe: MDAnalysis Universe with trajectory loaded.
+        lig_ag: Ligand AtomGroup.
+        prot_ag: Protein AtomGroup.
+        cutoff: Distance cutoff in Angstroms.
+        max_frames: Maximum frames to scan. If None, scan all frames.
+        stride: Frame stride for scanning. Default 1 scans every frame.
+
+    Returns:
+        Set of (resname, resid, segid) tuples for residues found within cutoff.
+    """
+    F_total = len(universe.trajectory)
+    F = F_total if not max_frames or max_frames <= 0 else min(F_total, int(max_frames))
+
+    residue_set: set[tuple[str, int, str]] = set()
+
+    for ts in universe.trajectory[:F:stride]:
+        box = ts.dimensions if ts.dimensions is not None and ts.dimensions[0] > 0 else None
+
+        pairs = capped_distance(
+            lig_ag.positions,
+            prot_ag.positions,
+            max_cutoff=cutoff,
+            box=box,
+            return_distances=False,
+        )
+
+        if pairs.size == 0:
+            continue
+
+        prot_indices = np.unique(pairs[:, 1])
+        nearby_atoms = prot_ag.atoms[prot_indices]
+
+        for res in nearby_atoms.residues:
+            residue_set.add((res.resname, res.resid, res.segid))
+
+    return residue_set
+
+
+def _residue_keys_to_ids(residue_keys: set[tuple[str, int, str]], prot_mol):
+    """Convert (resname, resid, segid) tuples to ProLIF ResidueId objects.
+
+    Matches residue keys against the protein molecule to retrieve the
+    corresponding ProLIF ResidueId objects, preserving the chain information.
+
+    Args:
+        residue_keys: Set of (resname, resid, segid) tuples.
+        prot_mol: ProLIF Molecule for the protein.
+
+    Returns:
+        List of matching ProLIF ResidueId objects.
+    """
+    matched_ids = []
+    for resname, resid, segid in sorted(residue_keys):
+        for rid in prot_mol.residues.keys():
+            if rid.name == resname and rid.number == resid:
+                if segid and rid.chain and rid.chain != segid:
+                    continue
+                matched_ids.append(rid)
+                break
+        else:
+            matched_ids.append(ResidueId(resname, resid, segid or None))
+
+    return matched_ids
+
+
+def analyze_trajectory(
+    universe: "mda.Universe",
+    ligand_selection: str = "resname LIG",
+    protein_selection: str = "protein",
+    *,
+    cutoff: float = 6.0,
+    max_frames: int | None = None,
+    device: str = "cpu",
+    chunk_size: int | None = None,
+    residue_mode: str = "all",
+    scan_stride: int = 1,
+) -> InteractionResult:
+    """Compute interaction fingerprints for all frames in a trajectory.
+
+    This is the main entry point for JAX-accelerated interaction analysis.
+    It handles all the complexity of coordinate extraction, SMARTS matching,
+    device placement, and memory-safe chunking.
+
+    Args:
+        universe: MDAnalysis Universe with trajectory loaded.
+        ligand_selection: MDAnalysis selection string for the ligand.
+        protein_selection: MDAnalysis selection string for the protein.
+        cutoff: Distance cutoff (Angstroms) for selecting residues near the ligand.
+        max_frames: Maximum number of frames to process. If None, process all.
+        device: 'cpu' or 'gpu'. GPU provides significant speedup for large trajectories.
+        chunk_size: Frames per GPU batch. If None, auto-calculated based on
+            available GPU memory. Ignored for CPU.
+        residue_mode: Residue selection strategy. Default is 'all'.
+            'all': Pre-scan all frames to find any residue that enters the
+                cutoff at any point. Correct for drifting or unbinding ligands.
+                Use residue_mode='first' to opt into faster setup for stable
+                bound systems where the ligand doesn't move much.
+            'first': Select residues within cutoff in the first frame only.
+                Fast setup, but misses residues that only come into contact
+                in later frames.
+        scan_stride: Frame stride for the 'all' mode pre-scan. Default 1 scans
+            every frame. Higher values reduce scan time at the cost of potentially
+            missing briefly-contacting residues. Ignored for 'first' mode.
+
+    Returns:
+        InteractionResult containing boolean arrays for each interaction type:
+        Hydrophobic, Cationic, Anionic, VdWContact, HBAcceptor, HBDonor,
+        PiStacking, CationPi, PiCation.
+
+    Example:
+        >>> import MDAnalysis as mda
+        >>> from prolif.interactions._jax import analyze_trajectory
+        >>>
+        >>> u = mda.Universe("topology.pdb", "trajectory.xtc")
+        >>> results = analyze_trajectory(
+        ...     u,
+        ...     ligand_selection="resname LIG",
+        ...     protein_selection="protein",
+        ...     device="gpu",
+        ...     residue_mode="all",
+        ... )
+        >>>
+        >>> hb_counts = results.interactions["HBDonor"].sum(axis=0)
+        >>> for rid, count in zip(results.residue_ids, hb_counts):
+        ...     if count > 0:
+        ...         print(f"{rid}: {count} HB donor contacts")
+    """
+    logger = logging.getLogger(__name__)
+
+    if residue_mode not in ("first", "all"):
+        raise ValueError(f"residue_mode must be 'first' or 'all', got '{residue_mode}'")
+
+    lig_ag = universe.select_atoms(ligand_selection)
+    prot_ag = universe.select_atoms(protein_selection)
+
+    if lig_ag.n_atoms == 0:
+        raise ValueError(f"Ligand selection '{ligand_selection}' matched no atoms")
+    if prot_ag.n_atoms == 0:
+        raise ValueError(f"Protein selection '{protein_selection}' matched no atoms")
+
+    universe.trajectory[0]
+
+    lig_mol = prolif.Molecule.from_mda(lig_ag)
+    prot_mol = prolif.Molecule.from_mda(prot_ag)
+
+    if residue_mode == "first":
+        residue_ids = get_residues_near_ligand(lig_mol, prot_mol, cutoff=cutoff)
+    else:
+        first_frame_ids = get_residues_near_ligand(lig_mol, prot_mol, cutoff=cutoff)
+
+        residue_keys = _scan_residues_all_frames(
+            universe, lig_ag, prot_ag, cutoff,
+            max_frames=max_frames, stride=scan_stride,
+        )
+        residue_ids = _residue_keys_to_ids(residue_keys, prot_mol)
+
+        logger.info(
+            "Residue scan complete: %d residues within %.1f A across trajectory "
+            "(first frame: %d residues)",
+            len(residue_ids), cutoff, len(first_frame_ids),
+        )
+
+        universe.trajectory[0]
+
+    residues = [prot_mol[rid] for rid in residue_ids]
+    residue_ags = _get_residue_ags_from_ids(prot_ag, residue_ids)
+
+    if not residues:
+        return InteractionResult(
+            interactions={
+                name: np.zeros((0, 0), dtype=bool)
+                for name in [
+                    "Hydrophobic", "Cationic", "Anionic", "VdWContact",
+                    "HBAcceptor", "HBDonor", "PiStacking", "CationPi", "PiCation",
+                ]
+            },
+            residue_ids=[],
+            n_frames=0,
+            n_residues=0,
+        )
+
+    lig_f, res_f, res_valid_mask = _build_trajectory_frames(
+        universe, lig_ag, residue_ags, max_frames=max_frames
+    )
+    F = int(lig_f.shape[0])
+
+    lig_masks, res_actor_masks = build_actor_masks(lig_mol, residues)
+    angle_idx = build_angle_indices(lig_ag, residue_ags)
+    ring_idx = build_ring_cation_indices(lig_mol, residues)
+    vdw_radii = build_vdw_radii(
+        lig_mol, residues, lig_ag=lig_ag, residue_ags=residue_ags, use_real=True
+    )
+
+    (
+        lig_f,
+        res_f,
+        res_valid_mask,
+        lig_masks,
+        res_actor_masks,
+        angle_idx,
+        ring_idx,
+        vdw_radii,
+    ) = prepare_for_device(
+        lig_f,
+        res_f,
+        res_valid_mask,
+        lig_masks,
+        res_actor_masks,
+        angle_idx,
+        ring_idx,
+        vdw_radii,
+        device=device,
+    )
+
+    if device == "gpu":
+        N = int(lig_f.shape[1])
+        R = int(res_f.shape[1])
+        M = int(res_f.shape[2])
+        if chunk_size is None:
+            chunk_size = calculate_chunk_size(N, R, M)
+        results = chunked_has_interactions_frames(
+            lig_f,
+            res_f,
+            res_valid_mask,
+            lig_masks,
+            res_actor_masks,
+            angle_idx,
+            ring_idx,
+            vdw_radii,
+            chunk_size=chunk_size,
+        )
+    else:
+        results = has_interactions_frames(
+            lig_f,
+            res_f,
+            res_valid_mask,
+            lig_masks,
+            res_actor_masks,
+            angle_idx,
+            ring_idx,
+            vdw_radii,
+        )
+
+    np_results = {k: np.asarray(v) for k, v in results.items()}
+
+    return InteractionResult(
+        interactions=np_results,
+        residue_ids=list(residue_ids),
+        n_frames=F,
+        n_residues=len(residues),
+    )
+
+
+def analyze_frame(
+    ligand,
+    protein,
+    *,
+    cutoff: float = 6.0,
+) -> dict[str, dict]:
+    """Compute interactions for a single frame (ProLIF Molecule objects).
+
+    This is a convenience function for single-frame analysis that accepts
+    ProLIF Molecule objects directly, matching the ProLIF API style.
+
+    Args:
+        ligand: ProLIF Molecule for the ligand.
+        protein: ProLIF Molecule for the protein.
+        cutoff: Distance cutoff for residue selection.
+
+    Returns:
+        Dict mapping ResidueId -> {interaction_name: bool}.
+    """
+    residue_ids = get_residues_near_ligand(ligand, protein, cutoff=cutoff)
+    residues = [protein[rid] for rid in residue_ids]
+
+    if not residues:
+        return {}
+
+    N = ligand.GetNumAtoms()
+    max_m = max(r.GetNumAtoms() for r in residues)
+
+    conf = ligand.GetConformer()
+    lig_coords = np.array([conf.GetAtomPosition(i) for i in range(N)], dtype=float)
+    lig_f = jnp.array(lig_coords[None, :, :])
+
+    res_coords = []
+    res_masks = []
+    for r in residues:
+        rc = r.GetConformer()
+        m = r.GetNumAtoms()
+        coords = np.array([rc.GetAtomPosition(i) for i in range(m)], dtype=float)
+        if m < max_m:
+            pad = np.zeros((max_m - m, 3), dtype=float)
+            coords = np.concatenate([coords, pad], axis=0)
+        res_coords.append(coords)
+        mask = np.zeros((max_m,), dtype=bool)
+        mask[:m] = True
+        res_masks.append(mask)
+
+    res_f = jnp.array(np.stack(res_coords, axis=0)[None, :, :, :])
+    res_valid_mask = jnp.array(np.stack(res_masks, axis=0))
+
+    lig_masks, res_actor_masks = build_actor_masks(ligand, residues)
+    angle_idx = _build_angle_indices_rdkit(ligand, residues)
+    ring_idx = build_ring_cation_indices(ligand, residues)
+    vdw_radii = build_vdw_radii(ligand, residues)
+
+    results = has_interactions_frames(
+        lig_f,
+        res_f,
+        res_valid_mask,
+        lig_masks,
+        res_actor_masks,
+        angle_idx,
+        ring_idx,
+        vdw_radii,
+    )
+
+    output = {}
+    for r_i, rid in enumerate(residue_ids):
+        output[rid] = {}
+        for name, arr in results.items():
+            output[rid][name] = bool(arr[0, r_i])
+    return output

--- a/prolif/interactions/_jax/api.py
+++ b/prolif/interactions/_jax/api.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import Any
 
 import jax.numpy as jnp
 import numpy as np
-import prolif
 from MDAnalysis.lib.distances import capped_distance
+
+import prolif
 from prolif import ResidueId
 from prolif.utils import get_residues_near_ligand
 
@@ -39,9 +40,6 @@ from .framebatch import (
     has_interactions_frames,
     prepare_for_device,
 )
-
-if TYPE_CHECKING:
-    import MDAnalysis as mda
 
 
 @dataclass
@@ -63,11 +61,11 @@ class InteractionResult:
     n_residues: int
     interaction_names: list[str] = field(default_factory=list)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.interaction_names:
             self.interaction_names = list(self.interactions.keys())
 
-    def to_dataframe(self):
+    def to_dataframe(self) -> Any:
         """Convert results to a pandas DataFrame with MultiIndex columns.
 
         Returns a DataFrame with shape (n_frames, n_residues * n_interactions)
@@ -81,7 +79,9 @@ class InteractionResult:
             names=["residue", "interaction"],
         )
 
-        reshaped = np.zeros((self.n_frames, self.n_residues * len(self.interaction_names)), dtype=bool)
+        reshaped = np.zeros(
+            (self.n_frames, self.n_residues * len(self.interaction_names)), dtype=bool
+        )
         for r_i in range(self.n_residues):
             for i_i, name in enumerate(self.interaction_names):
                 col_idx = r_i * len(self.interaction_names) + i_i
@@ -89,8 +89,11 @@ class InteractionResult:
 
         return pd.DataFrame(reshaped, columns=columns)
 
-    def get_contacts(self, interaction: str | None = None) -> list[tuple[int, "ResidueId", str]]:
-        """Get list of (frame_idx, residue_id, interaction_name) tuples where contacts occur.
+    def get_contacts(
+        self, interaction: str | None = None
+    ) -> list[tuple[int, "ResidueId", str]]:
+        """Get list of (frame_idx, residue_id, interaction_name) tuples
+        where contacts occur.
 
         Args:
             interaction: If specified, filter to only this interaction type.
@@ -114,7 +117,7 @@ class InteractionResult:
         Returns:
             Mapping from residue_id to {interaction_name: count}.
         """
-        result = {}
+        result: dict[ResidueId, dict[str, int]] = {}
         for r_i, rid in enumerate(self.residue_ids):
             result[rid] = {}
             for name in self.interaction_names:
@@ -127,7 +130,7 @@ class InteractionResult:
         Returns:
             Mapping from frame_index to {interaction_name: count}.
         """
-        result = {}
+        result: dict[int, dict[str, int]] = {}
         for f_i in range(self.n_frames):
             result[f_i] = {}
             for name in self.interaction_names:
@@ -135,7 +138,12 @@ class InteractionResult:
         return result
 
 
-def _build_trajectory_frames(u, lig_ag, residue_ags, max_frames: int | None = None):
+def _build_trajectory_frames(
+    u: Any,
+    lig_ag: Any,
+    residue_ags: list[Any],
+    max_frames: int | None = None,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Build per-frame coordinate arrays from MDAnalysis trajectory."""
     F_total = len(u.trajectory)
     F = F_total if not max_frames or max_frames <= 0 else min(F_total, int(max_frames))
@@ -180,18 +188,21 @@ def _build_trajectory_frames(u, lig_ag, residue_ags, max_frames: int | None = No
     return lig_f, res_f, res_valid_mask
 
 
-def _get_residue_ags_from_ids(prot_ag, residue_ids):
+def _get_residue_ags_from_ids(
+    prot_ag: Any,
+    residue_ids: list[ResidueId],
+) -> list[Any]:
     """Map ProLIF ResidueIds to MDAnalysis AtomGroups via direct residue lookup.
 
     Builds a lookup from (resname, resid, segid) to AtomGroup once, then
     matches each ResidueId directly without string-based selection.
     """
     by_key = {(r.resname, r.resid, r.segid): r.atoms for r in prot_ag.residues}
-    by_resname_resid = {}
+    by_resname_resid: dict[tuple[str, int], Any] = {}
     for r in prot_ag.residues:
         by_resname_resid.setdefault((r.resname, r.resid), r.atoms)
 
-    result = []
+    result: list[Any] = []
     for rid in residue_ids:
         key = (rid.name or "", rid.number, rid.chain or "")
         ag = by_key.get(key) or by_resname_resid.get((rid.name or "", rid.number))
@@ -202,9 +213,9 @@ def _get_residue_ags_from_ids(prot_ag, residue_ids):
 
 
 def _scan_residues_all_frames(
-    universe,
-    lig_ag,
-    prot_ag,
+    universe: Any,
+    lig_ag: Any,
+    prot_ag: Any,
     cutoff: float,
     max_frames: int | None = None,
     stride: int = 1,
@@ -232,7 +243,11 @@ def _scan_residues_all_frames(
     residue_set: set[tuple[str, int, str]] = set()
 
     for ts in universe.trajectory[:F:stride]:
-        box = ts.dimensions if ts.dimensions is not None and ts.dimensions[0] > 0 else None
+        box = (
+            ts.dimensions
+            if ts.dimensions is not None and ts.dimensions[0] > 0
+            else None
+        )
 
         pairs = capped_distance(
             lig_ag.positions,
@@ -248,13 +263,17 @@ def _scan_residues_all_frames(
         prot_indices = np.unique(pairs[:, 1])
         nearby_atoms = prot_ag.atoms[prot_indices]
 
-        for res in nearby_atoms.residues:
-            residue_set.add((res.resname, res.resid, res.segid))
+        residue_set.update(
+            (res.resname, res.resid, res.segid) for res in nearby_atoms.residues
+        )
 
     return residue_set
 
 
-def _residue_keys_to_ids(residue_keys: set[tuple[str, int, str]], prot_mol):
+def _residue_keys_to_ids(
+    residue_keys: set[tuple[str, int, str]],
+    prot_mol: Any,
+) -> list[ResidueId]:
     """Convert (resname, resid, segid) tuples to ProLIF ResidueId objects.
 
     Matches residue keys against the protein molecule to retrieve the
@@ -267,9 +286,9 @@ def _residue_keys_to_ids(residue_keys: set[tuple[str, int, str]], prot_mol):
     Returns:
         List of matching ProLIF ResidueId objects.
     """
-    matched_ids = []
+    matched_ids: list[ResidueId] = []
     for resname, resid, segid in sorted(residue_keys):
-        for rid in prot_mol.residues.keys():
+        for rid in prot_mol.residues:
             if rid.name == resname and rid.number == resid:
                 if segid and rid.chain and rid.chain != segid:
                     continue
@@ -282,7 +301,7 @@ def _residue_keys_to_ids(residue_keys: set[tuple[str, int, str]], prot_mol):
 
 
 def analyze_trajectory(
-    universe: "mda.Universe",
+    universe: Any,
     ligand_selection: str = "resname LIG",
     protein_selection: str = "protein",
     *,
@@ -345,7 +364,7 @@ def analyze_trajectory(
     """
     logger = logging.getLogger(__name__)
 
-    if residue_mode not in ("first", "all"):
+    if residue_mode not in {"first", "all"}:
         raise ValueError(f"residue_mode must be 'first' or 'all', got '{residue_mode}'")
 
     lig_ag = universe.select_atoms(ligand_selection)
@@ -367,15 +386,21 @@ def analyze_trajectory(
         first_frame_ids = get_residues_near_ligand(lig_mol, prot_mol, cutoff=cutoff)
 
         residue_keys = _scan_residues_all_frames(
-            universe, lig_ag, prot_ag, cutoff,
-            max_frames=max_frames, stride=scan_stride,
+            universe,
+            lig_ag,
+            prot_ag,
+            cutoff,
+            max_frames=max_frames,
+            stride=scan_stride,
         )
         residue_ids = _residue_keys_to_ids(residue_keys, prot_mol)
 
         logger.info(
             "Residue scan complete: %d residues within %.1f A across trajectory "
             "(first frame: %d residues)",
-            len(residue_ids), cutoff, len(first_frame_ids),
+            len(residue_ids),
+            cutoff,
+            len(first_frame_ids),
         )
 
         universe.trajectory[0]
@@ -388,8 +413,15 @@ def analyze_trajectory(
             interactions={
                 name: np.zeros((0, 0), dtype=bool)
                 for name in [
-                    "Hydrophobic", "Cationic", "Anionic", "VdWContact",
-                    "HBAcceptor", "HBDonor", "PiStacking", "CationPi", "PiCation",
+                    "Hydrophobic",
+                    "Cationic",
+                    "Anionic",
+                    "VdWContact",
+                    "HBAcceptor",
+                    "HBDonor",
+                    "PiStacking",
+                    "CationPi",
+                    "PiCation",
                 ]
             },
             residue_ids=[],
@@ -402,7 +434,7 @@ def analyze_trajectory(
     )
     F = int(lig_f.shape[0])
 
-    lig_res_for_smarts = list(lig_mol.residues.values())[0]
+    lig_res_for_smarts = next(iter(lig_mol.residues.values()))
     lig_masks, res_actor_masks = build_actor_masks(lig_mol, residues)
     angle_idx = build_angle_indices(lig_ag, residue_ags)
     ring_idx = build_ring_cation_indices(lig_res_for_smarts, residues)
@@ -472,11 +504,11 @@ def analyze_trajectory(
 
 
 def analyze_frame(
-    ligand,
-    protein,
+    ligand: Any,
+    protein: Any,
     *,
     cutoff: float = 6.0,
-) -> dict[str, dict]:
+) -> dict[ResidueId, dict[str, bool]]:
     """Compute interactions for a single frame (ProLIF Molecule objects).
 
     This is a convenience function for single-frame analysis that accepts
@@ -521,7 +553,7 @@ def analyze_frame(
     res_valid_mask = jnp.array(np.stack(res_masks, axis=0))
 
     lig_masks, res_actor_masks = build_actor_masks(ligand, residues)
-    angle_idx = _build_angle_indices_rdkit(ligand, residues)
+    angle_idx = build_angle_indices_rdkit(ligand, residues)
     ring_idx = build_ring_cation_indices(ligand, residues)
     vdw_radii = build_vdw_radii(ligand, residues)
 
@@ -537,7 +569,7 @@ def analyze_frame(
         vicinity_cutoff=cutoff,
     )
 
-    output = {}
+    output: dict[ResidueId, dict[str, bool]] = {}
     for r_i, rid in enumerate(residue_ids):
         output[rid] = {}
         for name, arr in results.items():

--- a/prolif/interactions/_jax/api.py
+++ b/prolif/interactions/_jax/api.py
@@ -402,9 +402,10 @@ def analyze_trajectory(
     )
     F = int(lig_f.shape[0])
 
+    lig_res_for_smarts = list(lig_mol.residues.values())[0]
     lig_masks, res_actor_masks = build_actor_masks(lig_mol, residues)
     angle_idx = build_angle_indices(lig_ag, residue_ags)
-    ring_idx = build_ring_cation_indices(lig_mol, residues)
+    ring_idx = build_ring_cation_indices(lig_res_for_smarts, residues)
     vdw_radii = build_vdw_radii(
         lig_mol, residues, lig_ag=lig_ag, residue_ags=residue_ags, use_real=True
     )
@@ -457,6 +458,7 @@ def analyze_trajectory(
             angle_idx,
             ring_idx,
             vdw_radii,
+            vicinity_cutoff=cutoff,
         )
 
     np_results = {k: np.asarray(v) for k, v in results.items()}
@@ -532,6 +534,7 @@ def analyze_frame(
         angle_idx,
         ring_idx,
         vdw_radii,
+        vicinity_cutoff=cutoff,
     )
 
     output = {}

--- a/prolif/interactions/_jax/api.py
+++ b/prolif/interactions/_jax/api.py
@@ -191,21 +191,28 @@ def _build_trajectory_frames(
 def _get_residue_ags_from_ids(
     prot_ag: Any,
     residue_ids: list[ResidueId],
+    use_segid: bool = False,
 ) -> list[Any]:
     """Map ProLIF ResidueIds to MDAnalysis AtomGroups via direct residue lookup.
 
     Builds a lookup from (resname, resid, segid) to AtomGroup once, then
     matches each ResidueId directly without string-based selection.
     """
-    by_key = {(r.resname, r.resid, r.segid): r.atoms for r in prot_ag.residues}
-    by_resname_resid: dict[tuple[str, int], Any] = {}
+    by_key: dict[tuple[str, int, str | None], Any] = {}
     for r in prot_ag.residues:
-        by_resname_resid.setdefault((r.resname, r.resid), r.atoms)
+        if use_segid:
+            chain = str(int(r.segindex))
+        else:
+            try:
+                chain = str(r.atoms[0].chainID).strip() or None
+            except Exception:
+                chain = None
+        by_key[(r.resname, r.resid, chain)] = r.atoms
 
     result: list[Any] = []
     for rid in residue_ids:
-        key = (rid.name or "", rid.number, rid.chain or "")
-        ag = by_key.get(key) or by_resname_resid.get((rid.name or "", rid.number))
+        key = (rid.name or "", rid.number, rid.chain)
+        ag = by_key.get(key)
         if ag is None:
             raise ValueError(f"Could not find residue {rid} in protein AtomGroup")
         result.append(ag)
@@ -219,7 +226,8 @@ def _scan_residues_all_frames(
     cutoff: float,
     max_frames: int | None = None,
     stride: int = 1,
-) -> set[tuple[str, int, str]]:
+    use_segid: bool = False,
+) -> set[tuple[str, int, str | None]]:
     """Scan all trajectory frames to find residues within cutoff of the ligand.
 
     Uses MDAnalysis capped_distance for efficient, PBC-aware neighbor searching.
@@ -240,7 +248,7 @@ def _scan_residues_all_frames(
     F_total = len(universe.trajectory)
     F = F_total if not max_frames or max_frames <= 0 else min(F_total, int(max_frames))
 
-    residue_set: set[tuple[str, int, str]] = set()
+    residue_set: set[tuple[str, int, str | None]] = set()
 
     for ts in universe.trajectory[:F:stride]:
         box = (
@@ -263,15 +271,21 @@ def _scan_residues_all_frames(
         prot_indices = np.unique(pairs[:, 1])
         nearby_atoms = prot_ag.atoms[prot_indices]
 
-        residue_set.update(
-            (res.resname, res.resid, res.segid) for res in nearby_atoms.residues
-        )
+        for res in nearby_atoms.residues:
+            if use_segid:
+                chain = str(int(res.segindex))
+            else:
+                try:
+                    chain = str(res.atoms[0].chainID).strip() or None
+                except Exception:
+                    chain = None
+            residue_set.add((res.resname, res.resid, chain))
 
     return residue_set
 
 
 def _residue_keys_to_ids(
-    residue_keys: set[tuple[str, int, str]],
+    residue_keys: set[tuple[str, int, str | None]],
     prot_mol: Any,
 ) -> list[ResidueId]:
     """Convert (resname, resid, segid) tuples to ProLIF ResidueId objects.
@@ -286,16 +300,15 @@ def _residue_keys_to_ids(
     Returns:
         List of matching ProLIF ResidueId objects.
     """
+    by_key = {(rid.name, rid.number, rid.chain): rid for rid in prot_mol.residues}
     matched_ids: list[ResidueId] = []
-    for resname, resid, segid in sorted(residue_keys):
-        for rid in prot_mol.residues:
-            if rid.name == resname and rid.number == resid:
-                if segid and rid.chain and rid.chain != segid:
-                    continue
-                matched_ids.append(rid)
-                break
-        else:
-            matched_ids.append(ResidueId(resname, resid, segid or None))
+    for key in sorted(
+        residue_keys, key=lambda x: (x[0], x[1], "" if x[2] is None else x[2])
+    ):
+        rid = by_key.get(key)
+        if rid is None:
+            raise KeyError(f"Could not map residue key {key} to a ProLIF ResidueId")
+        matched_ids.append(rid)
 
     return matched_ids
 
@@ -377,13 +390,20 @@ def analyze_trajectory(
 
     universe.trajectory[0]
 
-    lig_mol = prolif.Molecule.from_mda(lig_ag)
-    prot_mol = prolif.Molecule.from_mda(prot_ag)
+    use_segid = prolif.Molecule._use_segid(lig_ag) or prolif.Molecule._use_segid(
+        prot_ag
+    )
+    lig_mol = prolif.Molecule.from_mda(lig_ag, use_segid=use_segid)
+    prot_mol = prolif.Molecule.from_mda(prot_ag, use_segid=use_segid)
 
     if residue_mode == "first":
-        residue_ids = get_residues_near_ligand(lig_mol, prot_mol, cutoff=cutoff)
+        residue_ids = get_residues_near_ligand(
+            lig_mol, prot_mol, cutoff=cutoff, use_segid=use_segid
+        )
     else:
-        first_frame_ids = get_residues_near_ligand(lig_mol, prot_mol, cutoff=cutoff)
+        first_frame_ids = get_residues_near_ligand(
+            lig_mol, prot_mol, cutoff=cutoff, use_segid=use_segid
+        )
 
         residue_keys = _scan_residues_all_frames(
             universe,
@@ -392,6 +412,7 @@ def analyze_trajectory(
             cutoff,
             max_frames=max_frames,
             stride=scan_stride,
+            use_segid=use_segid,
         )
         residue_ids = _residue_keys_to_ids(residue_keys, prot_mol)
 
@@ -406,7 +427,7 @@ def analyze_trajectory(
         universe.trajectory[0]
 
     residues = [prot_mol[rid] for rid in residue_ids]
-    residue_ags = _get_residue_ags_from_ids(prot_ag, residue_ids)
+    residue_ags = _get_residue_ags_from_ids(prot_ag, residue_ids, use_segid=use_segid)
 
     if not residues:
         return InteractionResult(

--- a/prolif/interactions/_jax/framebatch.py
+++ b/prolif/interactions/_jax/framebatch.py
@@ -1,0 +1,1194 @@
+"""
+Frame-batched JAX helpers for MD trajectories.
+
+This module provides minimal, safe utilities to vectorize geometry across
+many frames while keeping indices fixed (SMARTS done once per system).
+
+Design goals:
+- Avoid residue-batched complexity (no per-residue index threading/padding).
+- Keep shapes stable across frames to enable JIT specialization.
+- Only implement clear wins; leave angles to the integration layer for now.
+
+API stability: experimental. Functions here are intentionally small and
+focused to avoid future breakage.
+"""
+
+from __future__ import annotations
+
+import math
+import subprocess
+
+import jax
+import jax.numpy as jnp
+import prolif
+from prolif.interactions import (
+    Anionic,
+    CationPi,
+    Cationic,
+    EdgeToFace,
+    FaceToFace,
+    HBAcceptor,
+    HBDonor,
+    Hydrophobic,
+    MetalAcceptor,
+    MetalDonor,
+    PiStacking,
+    VdWContact,
+    XBAcceptor,
+    XBDonor,
+)
+
+from .primitives import angle_at_vertex, angle_between_vectors, pairwise_distances
+
+try:
+    import pynvml
+except ImportError:
+    pynvml = None
+
+try:
+    from MDAnalysis.topology import guessers as mda_guessers
+except ImportError:
+    mda_guessers = None
+
+
+def pairwise_distances_frames(
+    lig_coords_f: jnp.ndarray,
+    res_coords_f: jnp.ndarray,
+) -> jnp.ndarray:
+    """Compute distances for each frame and residue in a trajectory.
+
+    Args:
+        lig_coords_f: (F, N, 3) ligand coordinates per frame.
+        res_coords_f: (F, R, M, 3) residue coordinates per frame
+            (padded to the same M across residues; masks handled upstream).
+
+    Returns:
+        (F, R, N, M) array of pairwise distances.
+
+    Notes:
+        - Shapes must be consistent across frames to avoid recompilation.
+        - This function does not apply masks; callers should mask padded
+          atoms as needed.
+    """
+
+    def _frame_distances(lig: jnp.ndarray, res_batch: jnp.ndarray) -> jnp.ndarray:
+        return jax.vmap(lambda rc: pairwise_distances(lig, rc))(res_batch)
+
+    return jax.vmap(_frame_distances)(lig_coords_f, res_coords_f)
+
+
+def hbacceptor_frames(
+    lig_coords_f: jnp.ndarray,
+    res_coords_f: jnp.ndarray,
+    acc_idx: jnp.ndarray,
+    d_idx: jnp.ndarray,
+    h_idx: jnp.ndarray,
+    *,
+    distance_cutoff: float = 3.5,
+    dha_angle_min: float = 130.0,
+    dha_angle_max: float = 180.0,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Frame-batched hydrogen bond (acceptor) geometry.
+
+    Args:
+        lig_coords_f: (F, N, 3) ligand coords per frame.
+        res_coords_f: (F, M, 3) residue coords per frame.
+        acc_idx: (Na,) ligand acceptor indices.
+        d_idx: (K,) residue donor indices.
+        h_idx: (K,) residue hydrogen indices (paired with donors).
+        distance_cutoff: Max A–D distance.
+        dha_angle_min/max: D–H–A angle limits (deg).
+
+    Returns:
+        mask: (F, Na, K) boolean
+        distances: (F, Na, K) A–D distances
+        angles: (F, Na, K) D–H–A angles (deg)
+    """
+    acc = lig_coords_f[:, acc_idx, :]
+    donors = res_coords_f[:, d_idx, :]
+    hydrogens = res_coords_f[:, h_idx, :]
+
+    dvec = acc[:, :, None, :] - donors[:, None, :, :]
+    dists = jnp.linalg.norm(dvec, axis=-1)
+    dc = jnp.nextafter(jnp.asarray(distance_cutoff, dists.dtype), jnp.inf)
+    dist_ok = dists <= dc
+
+    ang = angle_at_vertex(
+        donors[:, None, :, :],
+        hydrogens[:, None, :, :],
+        acc[:, :, None, :],
+    )
+    ang_deg = jnp.degrees(ang)
+    min_deg = jnp.nextafter(jnp.asarray(dha_angle_min, ang_deg.dtype), -jnp.inf)
+    max_deg = jnp.nextafter(jnp.asarray(dha_angle_max, ang_deg.dtype), jnp.inf)
+    ang_ok = (ang_deg >= min_deg) & (ang_deg <= max_deg)
+
+    mask = dist_ok & ang_ok
+    return mask, dists, ang_deg
+
+
+def hbdonor_frames(
+    lig_coords_f: jnp.ndarray,
+    res_coords_f: jnp.ndarray,
+    d_idx: jnp.ndarray,
+    h_idx: jnp.ndarray,
+    acc_idx: jnp.ndarray,
+    *,
+    distance_cutoff: float = 3.5,
+    dha_angle_min: float = 130.0,
+    dha_angle_max: float = 180.0,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Frame-batched hydrogen bond (donor) geometry (inverted).
+
+    The distance is measured between donor and acceptor heavy atoms to mirror
+    SingleAngle semantics after role inversion. The angle remains D–H–A in
+    degrees. Returns (mask, distances, angles) with shapes (F, Nd, Ka).
+    """
+    donors = lig_coords_f[:, d_idx, :]
+    hydrogens = lig_coords_f[:, h_idx, :]
+    acc = res_coords_f[:, acc_idx, :]
+
+    dvec = donors[:, :, None, :] - acc[:, None, :, :]
+    dists = jnp.linalg.norm(dvec, axis=-1)
+    dc = jnp.nextafter(jnp.asarray(distance_cutoff, dists.dtype), jnp.inf)
+    dist_ok = dists <= dc
+
+    ang = angle_at_vertex(donors[:, :, None, :], hydrogens[:, :, None, :], acc[:, None, :, :])
+    ang_deg = jnp.degrees(ang)
+    min_deg = jnp.nextafter(jnp.asarray(dha_angle_min, ang_deg.dtype), -jnp.inf)
+    max_deg = jnp.nextafter(jnp.asarray(dha_angle_max, ang_deg.dtype), jnp.inf)
+    ang_ok = (ang_deg >= min_deg) & (ang_deg <= max_deg)
+    mask = dist_ok & ang_ok
+    return mask, dists, ang_deg
+
+
+def xbacceptor_frames(
+    lig_coords_f: jnp.ndarray,
+    res_coords_f: jnp.ndarray,
+    a_idx: jnp.ndarray,
+    r_idx: jnp.ndarray,
+    x_idx: jnp.ndarray,
+    d_idx: jnp.ndarray,
+    *,
+    distance_cutoff: float = 3.5,
+    axd_angle_min: float = 130.0,
+    axd_angle_max: float = 180.0,
+    xar_angle_min: float = 80.0,
+    xar_angle_max: float = 140.0,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Frame-batched halogen bond (acceptor) geometry.
+
+    Returns (mask, distances[A–X], axd_angles, xar_angles) with shapes (F, Na, K).
+    """
+    acc = lig_coords_f[:, a_idx, :]
+    neigh = lig_coords_f[:, r_idx, :]
+    hal = res_coords_f[:, x_idx, :]
+    don = res_coords_f[:, d_idx, :]
+
+    dvec = acc[:, :, None, :] - hal[:, None, :, :]
+    dists = jnp.linalg.norm(dvec, axis=-1)
+    dist_ok = dists <= distance_cutoff
+
+    axd = angle_at_vertex(
+        acc[:, :, None, :],
+        hal[:, None, :, :],
+        don[:, None, :, :],
+    )
+    axd_deg = jnp.degrees(axd)
+    axd_ok = (axd_deg >= axd_angle_min) & (axd_deg <= axd_angle_max)
+
+    xar = angle_at_vertex(
+        hal[:, None, :, :],
+        acc[:, :, None, :],
+        neigh[:, :, None, :],
+    )
+    xar_deg = jnp.degrees(xar)
+    xar_ok = (xar_deg >= xar_angle_min) & (xar_deg <= xar_angle_max)
+
+    mask = dist_ok & axd_ok & xar_ok
+    return mask, dists, axd_deg, xar_deg
+
+
+def xbdonor_frames(
+    lig_coords_f: jnp.ndarray,
+    res_coords_f: jnp.ndarray,
+    x_idx: jnp.ndarray,
+    d_idx: jnp.ndarray,
+    a_idx: jnp.ndarray,
+    r_idx: jnp.ndarray,
+    *,
+    distance_cutoff: float = 3.5,
+    axd_angle_min: float = 130.0,
+    axd_angle_max: float = 180.0,
+    xar_angle_min: float = 80.0,
+    xar_angle_max: float = 140.0,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Frame-batched halogen bond (donor) geometry (inverted).
+
+    Returns (mask, distances[X–A], axd_angles, xar_angles) with shapes (F, Nx, Ka).
+    """
+    hal = lig_coords_f[:, x_idx, :]
+    don = lig_coords_f[:, d_idx, :]
+    acc = res_coords_f[:, a_idx, :]
+    neigh = res_coords_f[:, r_idx, :]
+
+    dvec = hal[:, :, None, :] - acc[:, None, :, :]
+    dists = jnp.linalg.norm(dvec, axis=-1)
+    dist_ok = dists <= distance_cutoff
+
+    axd = angle_at_vertex(
+        acc[:, None, :, :],
+        hal[:, :, None, :],
+        don[:, :, None, :],
+    )
+    axd_deg = jnp.degrees(axd)
+    axd_ok = (axd_deg >= axd_angle_min) & (axd_deg <= axd_angle_max)
+
+    xar = angle_at_vertex(
+        hal[:, :, None, :],
+        acc[:, None, :, :],
+        neigh[:, None, :, :],
+    )
+    xar_deg = jnp.degrees(xar)
+    xar_ok = (xar_deg >= xar_angle_min) & (xar_deg <= xar_angle_max)
+
+    mask = dist_ok & axd_ok & xar_ok
+    return mask, dists, axd_deg, xar_deg
+
+
+def _ring_centroids_normals_frames(
+    coords_f: jnp.ndarray,
+    rings: list[jnp.ndarray],
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Compute ring centroids and normals across frames for a list of rings.
+
+    Normals are computed using the same method as ProLIF's
+    ``get_ring_normal_vector``: cross product of unit vectors from the centroid
+    to the first two ring atoms.
+
+    Args:
+        coords_f: (F, N, 3) coordinates per frame
+        rings: list of index arrays (variable ring sizes allowed)
+
+    Returns:
+        centroids: (F, K, 3)
+        normals: (F, K, 3) unit normals
+    """
+    F = int(coords_f.shape[0])
+    centroids_list = []
+    normals_list = []
+    for ring_idx in rings:
+        rc = coords_f[:, ring_idx, :]
+        centroid = rc.mean(axis=1)
+        a = rc[:, 0, :] - centroid
+        b = rc[:, 1, :] - centroid
+        a_hat = a / jnp.clip(jnp.linalg.norm(a, axis=-1, keepdims=True), 1e-8)
+        b_hat = b / jnp.clip(jnp.linalg.norm(b, axis=-1, keepdims=True), 1e-8)
+        n = jnp.cross(a_hat, b_hat)
+        n = n / jnp.clip(jnp.linalg.norm(n, axis=-1, keepdims=True), 1e-8)
+        centroids_list.append(centroid)
+        normals_list.append(n)
+    if centroids_list:
+        centroids = jnp.stack(centroids_list, axis=1)
+        normals = jnp.stack(normals_list, axis=1)
+    else:
+        centroids = jnp.zeros((F, 0, 3))
+        normals = jnp.zeros((F, 0, 3))
+    return centroids, normals
+
+
+def cationpi_frames(
+    ring_coords_f: jnp.ndarray,
+    ring_list: list[jnp.ndarray],
+    cation_coords_f: jnp.ndarray,
+    cation_idx: jnp.ndarray,
+    *,
+    distance_cutoff: float = 4.5,
+    angle_min: float = 0.0,
+    angle_max: float = 30.0,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Frame-batched Cation–Pi geometry for one orientation (ring vs cation).
+
+    Angles are folded into [0, 90] to account for ring-normal sign ambiguity,
+    matching ProLIF's ``angle_between_limits(..., ring=True)`` behaviour.
+
+    Returns:
+        mask: (F, Kr, Kc)
+        distances: (F, Kr, Kc) centroid–cation distances
+        angles: (F, Kr, Kc) folded normal–centroid vector angles (deg)
+    """
+    F = int(ring_coords_f.shape[0])
+    centroids, normals = _ring_centroids_normals_frames(ring_coords_f, ring_list)
+    cations = cation_coords_f[:, cation_idx, :] if cation_idx.size else jnp.zeros((F, 0, 3))
+    if centroids.shape[1] == 0 or cations.shape[1] == 0:
+        z = jnp.zeros((F, centroids.shape[1], cations.shape[1]))
+        return z.astype(bool), z, z
+
+    vec = cations[:, None, :, :] - centroids[:, :, None, :]
+    dists = jnp.linalg.norm(vec, axis=-1)
+    dist_ok = dists <= distance_cutoff
+
+    ang = angle_between_vectors(normals[:, :, None, :], vec)
+    ang_deg = jnp.degrees(ang)
+    ang_deg = jnp.minimum(ang_deg, 180.0 - ang_deg)
+    ang_ok = (ang_deg >= angle_min) & (ang_deg <= angle_max)
+    mask = dist_ok & ang_ok
+    return mask, dists, ang_deg
+
+
+def _compute_intersect_check(
+    lc: jnp.ndarray,
+    ln: jnp.ndarray,
+    rc: jnp.ndarray,
+    rn: jnp.ndarray,
+    intersect_radius: float,
+) -> jnp.ndarray:
+    """Check if the ring-plane intersection line passes within radius of a centroid.
+
+    Replicates ProLIF's _get_intersect_point logic: finds the point on the
+    intersection line of the two ring planes closest to the ligand centroid,
+    then checks if that point is within intersect_radius of either centroid.
+
+    Args:
+        lc: (F, Kl, 3) ligand ring centroids.
+        ln: (F, Kl, 3) ligand ring normals.
+        rc: (F, Kr, 3) residue ring centroids.
+        rn: (F, Kr, 3) residue ring normals.
+        intersect_radius: Distance threshold in Angstroms.
+
+    Returns:
+        (F, Kl, Kr) boolean array, True where intersect_dist <= intersect_radius.
+    """
+    d = jnp.cross(ln[:, :, None, :], rn[:, None, :, :])
+    d_norm = jnp.linalg.norm(d, axis=-1, keepdims=True)
+    d_hat = d / jnp.where(d_norm > 1e-8, d_norm, jnp.ones_like(d_norm))
+
+    shape = d.shape
+    ln_exp = jnp.broadcast_to(ln[:, :, None, :], shape)
+    rn_exp = jnp.broadcast_to(rn[:, None, :, :], shape)
+    lc_exp = jnp.broadcast_to(lc[:, :, None, :], shape)
+    rc_exp = jnp.broadcast_to(rc[:, None, :, :], shape)
+
+    A = jnp.stack([ln_exp, rn_exp, d_hat], axis=-2)
+    ln_dot_lc = jnp.sum(ln_exp * lc_exp, axis=-1)
+    rn_dot_rc = jnp.sum(rn_exp * rc_exp, axis=-1)
+    b = jnp.stack([ln_dot_lc, rn_dot_rc, jnp.zeros_like(ln_dot_lc)], axis=-1)
+
+    det = jnp.linalg.det(A)
+    valid = jnp.abs(det) > 1e-8
+
+    safe_A = jnp.where(valid[..., None, None], A, jnp.eye(3))
+    safe_b = jnp.where(valid[..., None], b, jnp.zeros_like(b))
+    Q0 = jnp.linalg.solve(safe_A, safe_b[..., None]).squeeze(-1)
+
+    vec = lc_exp - Q0
+    scalar = jnp.sum(d_hat * vec, axis=-1, keepdims=True)
+    P_lig = Q0 + d_hat * scalar
+
+    dist_lig = jnp.linalg.norm(lc_exp - P_lig, axis=-1)
+    dist_res = jnp.linalg.norm(rc_exp - P_lig, axis=-1)
+    min_dist = jnp.minimum(dist_lig, dist_res)
+
+    return valid & (min_dist <= intersect_radius)
+
+
+def pistacking_frames(
+    lig_coords_f: jnp.ndarray,
+    lig_rings: list[jnp.ndarray],
+    res_coords_f: jnp.ndarray,
+    res_rings: list[jnp.ndarray],
+    *,
+    distance_cutoff: float = 6.5,
+    plane_angle_min: float = 0.0,
+    plane_angle_max: float = 30.0,
+    ncc_angle_min: float = 0.0,
+    ncc_angle_max: float = 60.0,
+    intersect: bool = False,
+    intersect_radius: float = 1.5,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Frame-batched Pi-stacking geometry for ring–ring pairs.
+
+    When ``intersect=True``, applies ProLIF's EdgeToFace intersection check:
+    the line of intersection of the two ring planes must pass within
+    ``intersect_radius`` of at least one centroid.
+
+    Returns:
+        mask: (F, Kl, Kr)
+        distances: (F, Kl, Kr) centroid–centroid distances
+        plane_angles: (F, Kl, Kr) normals plane angle (deg)
+        ncc_angles: (F, Kl, Kr) min of the two normal→centroid angles (deg)
+    """
+    F = int(lig_coords_f.shape[0])
+    lc, ln = _ring_centroids_normals_frames(lig_coords_f, lig_rings)
+    rc, rn = _ring_centroids_normals_frames(res_coords_f, res_rings)
+    if lc.shape[1] == 0 or rc.shape[1] == 0:
+        z = jnp.zeros((F, lc.shape[1], rc.shape[1]))
+        return z.astype(bool), z, z, z
+
+    cc_vec = rc[:, None, :, :] - lc[:, :, None, :]
+    dists = jnp.linalg.norm(cc_vec, axis=-1)
+    dist_ok = dists <= distance_cutoff
+
+    pa = angle_between_vectors(ln[:, :, None, :], rn[:, None, :, :])
+    pa_deg = jnp.degrees(pa)
+    pa_deg = jnp.minimum(pa_deg, 180.0 - pa_deg)
+    pa_ok = (pa_deg >= plane_angle_min) & (pa_deg <= plane_angle_max)
+
+    n1 = angle_between_vectors(ln[:, :, None, :], cc_vec)
+    n2 = angle_between_vectors(rn[:, None, :, :], -cc_vec)
+    n1_deg = jnp.minimum(jnp.degrees(n1), 180.0 - jnp.degrees(n1))
+    n2_deg = jnp.minimum(jnp.degrees(n2), 180.0 - jnp.degrees(n2))
+    n1_ok = (n1_deg >= ncc_angle_min) & (n1_deg <= ncc_angle_max)
+    n2_ok = (n2_deg >= ncc_angle_min) & (n2_deg <= ncc_angle_max)
+    ncc_ok = n1_ok | n2_ok
+    ncc_deg = jnp.minimum(n1_deg, n2_deg)
+
+    mask = dist_ok & pa_ok & ncc_ok
+    if intersect:
+        mask = mask & _compute_intersect_check(lc, ln, rc, rn, intersect_radius)
+    return mask, dists, pa_deg, ncc_deg
+
+
+def build_actor_masks(lig_mol, residues):
+    """Compute boolean masks for distance-only actor atoms.
+
+    Returns ligand and residue masks for Hydrophobic, Cationic, Anionic,
+    MetalDonor, and MetalAcceptor SMARTS patterns using ProLIF interactions.
+    Residue masks are padded to a common length across residues.
+
+    For interactions created via ``invert_role`` (Anionic, MetalAcceptor), the
+    stored lig_pattern/prot_pattern labels refer to the parent class roles, so
+    the patterns must be applied to the swapped sides to match ProLIF semantics.
+    """
+
+    _INVERTED = frozenset({'Anionic', 'MetalAcceptor'})
+
+    inters = {
+        'Hydrophobic': Hydrophobic(),
+        'Cationic': Cationic(),
+        'Anionic': Anionic(),
+        'MetalDonor': MetalDonor(),
+        'MetalAcceptor': MetalAcceptor(),
+    }
+
+    N = lig_mol.GetNumAtoms()
+    max_m = max((r.GetNumAtoms() for r in residues), default=0)
+
+    lig_masks = {}
+    res_masks = {}
+    for name, inter in inters.items():
+        inverted = name in _INVERTED
+        lig_pat = inter.prot_pattern if inverted else inter.lig_pattern
+        res_pat = inter.lig_pattern if inverted else inter.prot_pattern
+
+        lm = jnp.zeros((N,), dtype=bool)
+        lmatches = lig_mol.GetSubstructMatches(lig_pat)
+        if lmatches:
+            idxs = [m[0] for m in lmatches]
+            lm = lm.at[jnp.array(idxs)].set(True)
+        lig_masks[name] = lm
+
+        r_rows = []
+        for r in residues:
+            m = jnp.zeros((max_m,), dtype=bool)
+            pmatches = r.GetSubstructMatches(res_pat)
+            if pmatches:
+                idxs = [mm[0] for mm in pmatches]
+                mm = jnp.zeros((r.GetNumAtoms(),), dtype=bool)
+                mm = mm.at[jnp.array(idxs)].set(True)
+                m = m.at[:r.GetNumAtoms()].set(mm)
+            r_rows.append(m)
+        res_masks[name] = jnp.stack(r_rows, axis=0) if r_rows else jnp.zeros((0, 0), dtype=bool)
+
+    return lig_masks, res_masks
+
+
+def build_angle_indices_rdkit(lig_mol, residues):
+    """Precompute angle indices using RDKit molecules (internal helper).
+
+    This variant derives indices from ProLIF RDKit molecules. It is intended
+    for single-frame RDKit workflows. For real trajectories, prefer
+    ``build_angle_indices`` which derives indices from AtomGroups to align with
+    coordinate order.
+    """
+
+    hb_acc = HBAcceptor()
+    hb_don = HBDonor()
+    xb_acc = XBAcceptor()
+    xb_don = XBDonor()
+
+    hb_acc_idx = []
+    lmatches = lig_mol.GetSubstructMatches(hb_acc.lig_pattern)
+    if lmatches:
+        hb_acc_idx = [m[0] for m in lmatches]
+    hb_acc_idx = jnp.array(hb_acc_idx, dtype=int) if hb_acc_idx else jnp.zeros((0,), dtype=int)
+
+    hb_d_rows, hb_h_rows = [], []
+    for r in residues:
+        pmatches = r.GetSubstructMatches(hb_acc.prot_pattern)
+        pairs = []
+        for m in (pmatches or []):
+            if len(m) >= 2:
+                pairs.append((m[0], m[1]))
+        d = jnp.array([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        h = jnp.array([p[1] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        hb_d_rows.append(d)
+        hb_h_rows.append(h)
+
+    xb_a_rows, xb_r_rows = [], []
+    lmatches = lig_mol.GetSubstructMatches(xb_acc.lig_pattern)
+    a = [m[0] for m in lmatches] if lmatches else []
+    r = [m[1] for m in lmatches] if lmatches else []
+    xbacc_a_idx = jnp.array(a, dtype=int) if a else jnp.zeros((0,), dtype=int)
+    xbacc_r_idx = jnp.array(r, dtype=int) if r else jnp.zeros((0,), dtype=int)
+
+    xb_x_rows, xb_d_rows = [], []
+    for res in residues:
+        pmatches = res.GetSubstructMatches(xb_acc.prot_pattern)
+        pairs = []
+        for m in (pmatches or []):
+            if len(m) >= 2:
+                pairs.append((m[1], m[0]))
+        x = jnp.array([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        d = jnp.array([p[1] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        xb_x_rows.append(x)
+        xb_d_rows.append(d)
+
+    lmatches = lig_mol.GetSubstructMatches(hb_don.prot_pattern)
+    hb_lig_pairs = []
+    for m in (lmatches or []):
+        if len(m) >= 2:
+            hb_lig_pairs.append((m[0], m[1]))
+    hb_lig_d_idx = jnp.array([p[0] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
+    hb_lig_h_idx = jnp.array([p[1] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
+
+    hb_res_acc_rows = []
+    for res in residues:
+        pmatches = res.GetSubstructMatches(hb_don.lig_pattern)
+        acc = jnp.array([m[0] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
+        hb_res_acc_rows.append(acc)
+
+    lmatches = lig_mol.GetSubstructMatches(xb_don.lig_pattern)
+    xbdon_pairs = []
+    for m in (lmatches or []):
+        if len(m) >= 2:
+            xbdon_pairs.append((m[1], m[0]))
+    xbdon_lig_x_idx = jnp.array([p[0] for p in xbdon_pairs], dtype=int) if xbdon_pairs else jnp.zeros((0,), dtype=int)
+    xbdon_lig_d_idx = jnp.array([p[1] for p in xbdon_pairs], dtype=int) if xbdon_pairs else jnp.zeros((0,), dtype=int)
+
+    xbdon_res_a_rows, xbdon_res_r_rows = [], []
+    for res in residues:
+        pmatches = res.GetSubstructMatches(xb_don.lig_pattern)
+        a = jnp.array([m[0] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
+        r = jnp.array([m[1] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
+        xbdon_res_a_rows.append(a)
+        xbdon_res_r_rows.append(r)
+
+    return {
+        'hb': {
+            'acc_idx': hb_acc_idx,
+            'res_d_idx': hb_d_rows,
+            'res_h_idx': hb_h_rows,
+        },
+        'hb_donor': {
+            'lig_d_idx': hb_lig_d_idx,
+            'lig_h_idx': hb_lig_h_idx,
+            'res_a_idx': hb_res_acc_rows,
+        },
+        'xbacc': {
+            'lig_a_idx': xbacc_a_idx,
+            'lig_r_idx': xbacc_r_idx,
+            'res_x_idx': xb_x_rows,
+            'res_d_idx': xb_d_rows,
+        },
+        'xbdon': {
+            'lig_x_idx': xbdon_lig_x_idx,
+            'lig_d_idx': xbdon_lig_d_idx,
+            'res_a_idx': xbdon_res_a_rows,
+            'res_r_idx': xbdon_res_r_rows,
+        },
+    }
+
+
+def build_angle_indices(lig_ag, residue_ags):
+    """Build angle indices from AtomGroups for real-frame alignment.
+
+    Derives RDKit molecules directly from the provided MDAnalysis AtomGroups
+    so that returned indices use the same atom ordering as the coordinate
+    arrays built from those groups.
+
+    Returns a dict with the same structure as the RDKit-based variant for the
+    hydrogen-bond orientation pairs. Halogen-bond entries are returned as empty
+    arrays for API completeness.
+    """
+
+    lig_mol = prolif.Molecule.from_mda(lig_ag)
+    res_mols = [prolif.Molecule.from_mda(ag) for ag in residue_ags]
+
+    hb_acc = HBAcceptor()
+    hb_don = HBDonor()
+    hb_acc_idx = []
+    lmatches = lig_mol.GetSubstructMatches(hb_acc.lig_pattern)
+    if lmatches:
+        hb_acc_idx = [m[0] for m in lmatches]
+    hb_acc_idx = jnp.array(hb_acc_idx, dtype=int) if hb_acc_idx else jnp.zeros((0,), dtype=int)
+
+    hb_d_rows, hb_h_rows = [], []
+    for r in res_mols:
+        pmatches = r.GetSubstructMatches(hb_acc.prot_pattern)
+        pairs = []
+        for m in (pmatches or []):
+            if len(m) >= 2:
+                pairs.append((m[0], m[1]))
+        d = jnp.array([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        h = jnp.array([p[1] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        hb_d_rows.append(d)
+        hb_h_rows.append(h)
+
+    lmatches = lig_mol.GetSubstructMatches(hb_don.prot_pattern)
+    hb_lig_pairs = []
+    for m in (lmatches or []):
+        if len(m) >= 2:
+            hb_lig_pairs.append((m[0], m[1]))
+    hb_lig_d_idx = jnp.array([p[0] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
+    hb_lig_h_idx = jnp.array([p[1] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
+
+    hb_res_acc_rows = []
+    for r in res_mols:
+        pmatches = r.GetSubstructMatches(hb_don.lig_pattern)
+        acc = jnp.array([m[0] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
+        hb_res_acc_rows.append(acc)
+
+    return {
+        'hb': {
+            'acc_idx': hb_acc_idx,
+            'res_d_idx': hb_d_rows,
+            'res_h_idx': hb_h_rows,
+        },
+        'hb_donor': {
+            'lig_d_idx': hb_lig_d_idx,
+            'lig_h_idx': hb_lig_h_idx,
+            'res_a_idx': hb_res_acc_rows,
+        },
+        'xbacc': {
+            'lig_a_idx': jnp.zeros((0,), dtype=int),
+            'lig_r_idx': jnp.zeros((0,), dtype=int),
+            'res_x_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
+            'res_d_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
+        },
+        'xbdon': {
+            'lig_x_idx': jnp.zeros((0,), dtype=int),
+            'lig_d_idx': jnp.zeros((0,), dtype=int),
+            'res_a_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
+            'res_r_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
+        },
+    }
+
+
+def build_ring_cation_indices(lig_mol, residues):
+    """Precompute ring and cation indices for ring-based interactions.
+
+    Uses ProLIF patterns to find aromatic rings and cations on the ligand and
+    per residue; returns lists of ring index arrays and arrays of cation indices.
+    """
+
+    pi = PiStacking()
+    ftf = FaceToFace()
+    etf = EdgeToFace()
+    ring_patterns = getattr(ftf, "pi_ring", []) or getattr(etf, "pi_ring", [])
+    lig_rings = []
+    for pat in ring_patterns:
+        for m in lig_mol.GetSubstructMatches(pat):
+            lig_rings.append(jnp.array(list(m), dtype=int))
+    res_rings = []
+    for r in residues:
+        rr = []
+        for pat in ring_patterns:
+            for m in r.GetSubstructMatches(pat):
+                rr.append(jnp.array(list(m), dtype=int))
+        res_rings.append(rr)
+
+    cp = CationPi()
+    lmatches = lig_mol.GetSubstructMatches(cp.cation)
+    lig_cations = jnp.array([m[0] for m in lmatches], dtype=int) if lmatches else jnp.zeros((0,), dtype=int)
+    res_cations = []
+    for r in residues:
+        pm = r.GetSubstructMatches(cp.cation)
+        rc = jnp.array([m[0] for m in pm], dtype=int) if pm else jnp.zeros((0,), dtype=int)
+        res_cations.append(rc)
+
+    return {
+        'lig_rings': lig_rings,
+        'res_rings': res_rings,
+        'lig_cations': lig_cations,
+        'res_cations': res_cations,
+        'pi': pi,
+        'cp': cp,
+    }
+
+
+def build_vdw_radii(
+    lig_mol,
+    residues,
+    *,
+    lig_ag=None,
+    residue_ags=None,
+    use_real: bool = False,
+):
+    """Build per-atom van der Waals radii arrays aligned with coordinate order.
+
+    When ``use_real`` is True, radii are derived from MDAnalysis AtomGroups to
+    match the coordinate ordering in real-frame mode. Otherwise, radii are
+    derived from RDKit molecules to match duplicate-frame mode.
+
+    Returns ligand radii (N,), residue radii (R, M) padded to max M, and
+    ProLIF's VdW tolerance.
+    """
+
+    def _symbol_from_atom(atom):
+        try:
+            sym = atom.element
+        except Exception:
+            sym = None
+        if not sym:
+            if mda_guessers is not None:
+                try:
+                    sym = mda_guessers.guess_atom_element(getattr(atom, 'name', ''))
+                except Exception:
+                    sym = 'C'
+            else:
+                sym = 'C'
+        return str(sym).capitalize()
+
+    vdw = VdWContact()
+
+    if use_real:
+        if lig_ag is None or residue_ags is None:
+            raise ValueError("lig_ag and residue_ags must be provided when use_real=True")
+        lig_elems = [_symbol_from_atom(a) for a in lig_ag.atoms]
+        lig_radii = jnp.array([vdw.vdwradii.get(e, 1.7) for e in lig_elems], dtype=float)
+
+        max_m = max((ag.n_atoms for ag in residue_ags), default=0)
+        res_rows = []
+        for ag in residue_ags:
+            elems = [_symbol_from_atom(a) for a in ag.atoms]
+            row = jnp.array([vdw.vdwradii.get(e, 1.7) for e in elems], dtype=float)
+            if ag.n_atoms < max_m:
+                pad = jnp.zeros((max_m - ag.n_atoms,), dtype=float)
+                row = jnp.concatenate([row, pad], axis=0)
+            res_rows.append(row)
+        res_radii = jnp.stack(res_rows, axis=0) if res_rows else jnp.zeros((0, 0), dtype=float)
+    else:
+        N = lig_mol.GetNumAtoms()
+        lig_elems = [lig_mol.GetAtomWithIdx(i).GetSymbol() for i in range(N)]
+        lig_radii = jnp.array([vdw.vdwradii.get(e, 1.7) for e in lig_elems], dtype=float)
+
+        max_m = max((r.GetNumAtoms() for r in residues), default=0)
+        res_rows = []
+        for r in residues:
+            m = r.GetNumAtoms()
+            elems = [r.GetAtomWithIdx(i).GetSymbol() for i in range(m)]
+            row = jnp.array([vdw.vdwradii.get(e, 1.7) for e in elems], dtype=float)
+            if m < max_m:
+                pad = jnp.zeros((max_m - m,), dtype=float)
+                row = jnp.concatenate([row, pad], axis=0)
+            res_rows.append(row)
+        res_radii = jnp.stack(res_rows, axis=0) if res_rows else jnp.zeros((0, 0), dtype=float)
+
+    return lig_radii, res_radii, float(vdw.tolerance)
+
+
+def has_interactions_frames(
+    lig_f: jnp.ndarray,
+    res_f: jnp.ndarray,
+    res_valid_mask: jnp.ndarray,
+    lig_masks: dict,
+    res_actor_masks: dict,
+    angle_idx: dict,
+    ring_idx: dict,
+    vdw_radii: tuple,
+) -> dict[str, jnp.ndarray]:
+    """Evaluate nine interactions across frames and residues, returning booleans.
+
+    Returns a mapping name → (F, R) boolean arrays for:
+    Hydrophobic, Cationic, Anionic, VdWContact, HBAcceptor, HBDonor,
+    PiStacking, CationPi, PiCation.
+    """
+    F = int(lig_f.shape[0])
+    R = int(res_f.shape[1]) if res_f.ndim == 4 else 0
+    results = {}
+
+    d = pairwise_distances_frames(lig_f, res_f)
+
+    m = (d <= 4.5) & lig_masks['Hydrophobic'][None, None, :, None] & (res_actor_masks['Hydrophobic'] & res_valid_mask)[None, :, None, :]
+    results['Hydrophobic'] = jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
+
+    for k in ('Cationic', 'Anionic'):
+        m = (d <= 4.5) & lig_masks[k][None, None, :, None] & (res_actor_masks[k] & res_valid_mask)[None, :, None, :]
+        results[k] = jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
+
+    lig_radii, res_radii, vdw_tol = vdw_radii
+    radii_sum = lig_radii[None, None, :, None] + res_radii[None, :, None, :]
+    m = (d <= (radii_sum + vdw_tol)) & res_valid_mask[None, :, None, :]
+    results['VdWContact'] = jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
+
+    acc_idx = angle_idx['hb']['acc_idx']
+    hb_acc_out = []
+    for r_i in range(R):
+        d_idx = angle_idx['hb']['res_d_idx'][r_i]
+        h_idx = angle_idx['hb']['res_h_idx'][r_i]
+        if acc_idx.size and d_idx.size:
+            _m, _, _ = hbacceptor_frames(lig_f, res_f[:, r_i, :, :], acc_idx, d_idx, h_idx)
+            hb_acc_out.append(jnp.any(_m, axis=(1, 2)))
+        else:
+            hb_acc_out.append(jnp.zeros((F,), dtype=bool))
+    results['HBAcceptor'] = jnp.stack(hb_acc_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+
+    hb_don_out = []
+    lig_d = angle_idx['hb_donor']['lig_d_idx']
+    lig_h = angle_idx['hb_donor']['lig_h_idx']
+    for r_i in range(R):
+        acc = angle_idx['hb_donor']['res_a_idx'][r_i]
+        if lig_d.size and acc.size:
+            _m, _, _ = hbdonor_frames(lig_f, res_f[:, r_i, :, :], lig_d, lig_h, acc)
+            hb_don_out.append(jnp.any(_m, axis=(1, 2)))
+        else:
+            hb_don_out.append(jnp.zeros((F,), dtype=bool))
+    results['HBDonor'] = jnp.stack(hb_don_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+
+    lig_rings = ring_idx['lig_rings']
+    res_rings = ring_idx['res_rings']
+    lig_cations = ring_idx['lig_cations']
+    res_cations = ring_idx['res_cations']
+    pi = ring_idx['pi']
+    cp = ring_idx['cp']
+
+    cationpi_out = []
+    picat_out = []
+    for r_i in range(R):
+        has_cationpi = jnp.zeros((F,), dtype=bool)
+        has_picat = jnp.zeros((F,), dtype=bool)
+        if lig_cations.size and len(res_rings[r_i]):
+            _m, _, _ = cationpi_frames(
+                res_f[:, r_i, :, :], res_rings[r_i], lig_f, lig_cations,
+                distance_cutoff=float(cp.distance),
+                angle_min=math.degrees(float(cp.angle[0])),
+                angle_max=math.degrees(float(cp.angle[1])),
+            )
+            has_cationpi = jnp.any(_m, axis=(1, 2))
+        if len(lig_rings) and res_cations[r_i].size:
+            _m, _, _ = cationpi_frames(
+                lig_f, lig_rings, res_f[:, r_i, :, :], res_cations[r_i],
+                distance_cutoff=float(cp.distance),
+                angle_min=math.degrees(float(cp.angle[0])),
+                angle_max=math.degrees(float(cp.angle[1])),
+            )
+            has_picat = jnp.any(_m, axis=(1, 2))
+        cationpi_out.append(has_cationpi)
+        picat_out.append(has_picat)
+    results['CationPi'] = jnp.stack(cationpi_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    results['PiCation'] = jnp.stack(picat_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+
+    ps_out = []
+    for r_i in range(R):
+        if len(lig_rings) and len(res_rings[r_i]):
+            ftf = pi.ftf
+            mF, _, _, _ = pistacking_frames(
+                lig_f, lig_rings, res_f[:, r_i, :, :], res_rings[r_i],
+                distance_cutoff=float(ftf.distance),
+                plane_angle_min=math.degrees(float(ftf.plane_angle[0])),
+                plane_angle_max=math.degrees(float(ftf.plane_angle[1])),
+                ncc_angle_min=math.degrees(float(ftf.normal_to_centroid_angle[0])),
+                ncc_angle_max=math.degrees(float(ftf.normal_to_centroid_angle[1])),
+            )
+            etf = pi.etf
+            mE, _, _, _ = pistacking_frames(
+                lig_f, lig_rings, res_f[:, r_i, :, :], res_rings[r_i],
+                distance_cutoff=float(etf.distance),
+                plane_angle_min=math.degrees(float(etf.plane_angle[0])),
+                plane_angle_max=math.degrees(float(etf.plane_angle[1])),
+                ncc_angle_min=math.degrees(float(etf.normal_to_centroid_angle[0])),
+                ncc_angle_max=math.degrees(float(etf.normal_to_centroid_angle[1])),
+                intersect=True,
+                intersect_radius=float(etf.intersect_radius),
+            )
+            ps_out.append(jnp.any(mF | mE, axis=(1, 2)))
+        else:
+            ps_out.append(jnp.zeros((F,), dtype=bool))
+    results['PiStacking'] = jnp.stack(ps_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+
+    return results
+
+
+def prepare_for_device(
+    lig_f: jnp.ndarray,
+    res_f: jnp.ndarray,
+    res_valid_mask: jnp.ndarray,
+    lig_masks: dict,
+    res_actor_masks: dict,
+    angle_idx: dict,
+    ring_idx: dict,
+    vdw_radii: tuple,
+    device: str = 'cpu',
+) -> tuple:
+    """Move frame-batched, small metadata arrays to a target device.
+
+    Args:
+        lig_f: (F, N, 3) ligand coordinates per frame.
+        res_f: (F, R, M, 3) residue coordinates per frame.
+        res_valid_mask: (R, M) boolean mask for valid atoms.
+        lig_masks: Dict of ligand SMARTS masks per interaction.
+        res_actor_masks: Dict of residue SMARTS masks per interaction.
+        angle_idx: Dict of angle indices from build_angle_indices.
+        ring_idx: Dict of ring indices from build_ring_cation_indices.
+        vdw_radii: Tuple of (lig_radii, res_radii, tolerance).
+        device: 'cpu' or 'gpu'. Coordinates remain on host; chunks are moved
+            transiently during computation. Reused small structures (masks,
+            indices, radii) are placed on the device.
+
+    Returns:
+        Tuple of all inputs moved to the specified device.
+        Returns unchanged inputs if device='cpu' or no GPU available.
+    """
+    if device != 'gpu':
+        return lig_f, res_f, res_valid_mask, lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+
+    gpus = jax.devices('gpu')
+    if not gpus:
+        return lig_f, res_f, res_valid_mask, lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+
+    dev = gpus[0]
+
+    res_valid_mask = jax.device_put(res_valid_mask, device=dev)
+    lig_masks = jax.tree_util.tree_map(lambda x: jax.device_put(x, device=dev), lig_masks)
+    res_actor_masks = jax.tree_util.tree_map(lambda x: jax.device_put(x, device=dev), res_actor_masks)
+
+    angle_idx = {
+        'hb': {
+            'acc_idx': jax.device_put(angle_idx['hb']['acc_idx'], device=dev),
+            'res_d_idx': [jax.device_put(a, device=dev) for a in angle_idx['hb']['res_d_idx']],
+            'res_h_idx': [jax.device_put(a, device=dev) for a in angle_idx['hb']['res_h_idx']],
+        },
+        'hb_donor': {
+            'lig_d_idx': jax.device_put(angle_idx['hb_donor']['lig_d_idx'], device=dev),
+            'lig_h_idx': jax.device_put(angle_idx['hb_donor']['lig_h_idx'], device=dev),
+            'res_a_idx': [jax.device_put(a, device=dev) for a in angle_idx['hb_donor']['res_a_idx']],
+        },
+        'xbacc': {
+            'lig_a_idx': jax.device_put(angle_idx['xbacc']['lig_a_idx'], device=dev),
+            'lig_r_idx': jax.device_put(angle_idx['xbacc']['lig_r_idx'], device=dev),
+            'res_x_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbacc']['res_x_idx']],
+            'res_d_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbacc']['res_d_idx']],
+        },
+        'xbdon': {
+            'lig_x_idx': jax.device_put(angle_idx['xbdon']['lig_x_idx'], device=dev),
+            'lig_d_idx': jax.device_put(angle_idx['xbdon']['lig_d_idx'], device=dev),
+            'res_a_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbdon']['res_a_idx']],
+            'res_r_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbdon']['res_r_idx']],
+        },
+    }
+
+    ring_idx = {
+        'lig_rings': [jax.device_put(a, device=dev) for a in ring_idx['lig_rings']],
+        'res_rings': [[jax.device_put(a, device=dev) for a in rr] for rr in ring_idx['res_rings']],
+        'lig_cations': jax.device_put(ring_idx['lig_cations'], device=dev),
+        'res_cations': [jax.device_put(a, device=dev) for a in ring_idx['res_cations']],
+        'pi': ring_idx['pi'],
+        'cp': ring_idx['cp'],
+    }
+
+    lr, rr, vdw_tol = vdw_radii
+    vdw_radii = (
+        jax.device_put(lr, device=dev),
+        jax.device_put(rr, device=dev),
+        vdw_tol,
+    )
+
+    return lig_f, res_f, res_valid_mask, lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+
+
+def get_gpu_device():
+    """Return the first GPU device if available, else None.
+
+    Safe on CPU-only installs where requesting 'gpu' would raise.
+    """
+    try:
+        gpus = jax.devices('gpu')
+    except Exception:
+        return None
+    return gpus[0] if gpus else None
+
+
+def get_gpu_memory_info() -> tuple[float, float] | None:
+    """Return (free_mb, total_mb) for GPU 0 if available, else None.
+
+    Tries NVML first, then falls back to parsing `nvidia-smi` output.
+    """
+    dev = get_gpu_device()
+    if dev is None:
+        return None
+
+    if pynvml is not None:
+        try:
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            free_mb = info.free / (1024 * 1024)
+            total_mb = info.total / (1024 * 1024)
+            return float(free_mb), float(total_mb)
+        except Exception:
+            pass
+
+    try:
+        out = subprocess.check_output([
+            'nvidia-smi',
+            '--query-gpu=memory.free,memory.total',
+            '--format=csv,noheader,nounits'
+        ], stderr=subprocess.STDOUT, text=True)
+        line = out.strip().splitlines()[0]
+        cols = [c.strip() for c in line.split(',')]
+        free_mb = float(cols[0])
+        total_mb = float(cols[1])
+        return free_mb, total_mb
+    except Exception:
+        return None
+
+
+def estimate_memory_per_frame(
+    n_ligand_atoms: int,
+    n_residues: int,
+    max_residue_atoms: int,
+) -> float:
+    """Estimate GPU memory usage per frame in bytes.
+
+    This is a rough estimate accounting for:
+        - Distance matrices: R × N × M × 4 bytes
+        - Intermediate arrays and masks
+        - JAX overhead multiplier (~3x for JIT buffers)
+
+    Args:
+        n_ligand_atoms: Number of ligand atoms (N).
+        n_residues: Number of residues (R).
+        max_residue_atoms: Max atoms per residue (M).
+
+    Returns:
+        Estimated bytes per frame.
+    """
+    N, R, M = n_ligand_atoms, n_residues, max_residue_atoms
+
+    coords_lig = N * 3 * 4
+    coords_res = R * M * 3 * 4
+    distance_matrix = R * N * M * 4
+    masks_and_results = R * N * M * 4
+
+    base = coords_lig + coords_res + distance_matrix + masks_and_results
+
+    overhead_multiplier = 3.0
+
+    return base * overhead_multiplier
+
+
+def calculate_chunk_size(
+    n_ligand_atoms: int,
+    n_residues: int,
+    max_residue_atoms: int,
+    available_memory_mb: float | None = None,
+    memory_fraction: float = 0.7,
+) -> int:
+    """Calculate safe chunk size (frames per batch) for GPU.
+
+    Args:
+        n_ligand_atoms: Number of ligand atoms.
+        n_residues: Number of residues.
+        max_residue_atoms: Max atoms per residue.
+        available_memory_mb: GPU memory in MB. If None, auto-detect.
+        memory_fraction: Fraction of memory to use (default 0.7 for safety).
+
+    Returns:
+        Recommended number of frames per chunk.
+    """
+    if available_memory_mb is None:
+        mem = get_gpu_memory_info()
+        if mem is None:
+            return 1000
+        available_memory_mb, total_mb = mem[0], mem[1]
+
+    bytes_per_frame = estimate_memory_per_frame(
+        n_ligand_atoms, n_residues, max_residue_atoms
+    )
+
+    usable_bytes = available_memory_mb * 1024 * 1024 * memory_fraction
+    chunk_size = int(usable_bytes / bytes_per_frame)
+
+    chunk_size = max(1, min(chunk_size, 10000))
+
+    return chunk_size
+
+
+def chunked_has_interactions_frames(
+    lig_f: jnp.ndarray,
+    res_f: jnp.ndarray,
+    res_valid_mask: jnp.ndarray,
+    lig_masks: dict,
+    res_actor_masks: dict,
+    angle_idx: dict,
+    ring_idx: dict,
+    vdw_radii: tuple,
+    chunk_size: int | None = None,
+) -> dict[str, jnp.ndarray]:
+    """Evaluate interactions in memory-safe chunks.
+
+    Automatically chunks large trajectories to avoid GPU OOM.
+    Results are concatenated along the frame dimension.
+
+    Args:
+        lig_f: (F, N, 3) ligand coordinates.
+        res_f: (F, R, M, 3) residue coordinates.
+        res_valid_mask: (R, M) valid atom mask.
+        lig_masks: SMARTS masks per interaction.
+        res_actor_masks: Residue SMARTS masks.
+        angle_idx: Angle indices dict.
+        ring_idx: Ring indices dict.
+        vdw_radii: VdW radii tuple.
+        chunk_size: Frames per chunk. If None, auto-calculate.
+
+    Returns:
+        Dict of interaction name → (F, R) boolean arrays.
+    """
+    F = int(lig_f.shape[0])
+    N = int(lig_f.shape[1])
+    R = int(res_f.shape[1])
+    M = int(res_f.shape[2])
+
+    if chunk_size is None:
+        chunk_size = calculate_chunk_size(N, R, M)
+
+    dev = get_gpu_device()
+
+    all_results = []
+    for i in range(0, F, chunk_size):
+        j = min(i + chunk_size, F)
+
+        if dev is not None:
+            chunk_lig = jax.device_put(lig_f[i:j], device=dev)
+            chunk_res = jax.device_put(res_f[i:j], device=dev)
+        else:
+            chunk_lig = lig_f[i:j]
+            chunk_res = res_f[i:j]
+
+        chunk_result = has_interactions_frames(
+            chunk_lig, chunk_res, res_valid_mask,
+            lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+        )
+
+        chunk_result = jax.device_get(chunk_result)
+        all_results.append(chunk_result)
+
+    if len(all_results) == 1:
+        return all_results[0]
+
+    combined = {}
+    for key in all_results[0].keys():
+        combined[key] = jnp.concatenate([r[key] for r in all_results], axis=0)
+
+    return combined

--- a/prolif/interactions/_jax/framebatch.py
+++ b/prolif/interactions/_jax/framebatch.py
@@ -17,14 +17,16 @@ from __future__ import annotations
 
 import math
 import subprocess
+from typing import Any
 
 import jax
 import jax.numpy as jnp
+
 import prolif
 from prolif.interactions import (
     Anionic,
-    CationPi,
     Cationic,
+    CationPi,
     EdgeToFace,
     FaceToFace,
     HBAcceptor,
@@ -41,7 +43,7 @@ from prolif.interactions import (
 from .primitives import angle_at_vertex, angle_between_vectors, pairwise_distances
 
 try:
-    import pynvml
+    import pynvml  # type: ignore[import-untyped]
 except ImportError:
     pynvml = None
 
@@ -96,13 +98,13 @@ def hbacceptor_frames(
         acc_idx: (Na,) ligand acceptor indices.
         d_idx: (K,) residue donor indices.
         h_idx: (K,) residue hydrogen indices (paired with donors).
-        distance_cutoff: Max A–D distance.
-        dha_angle_min/max: D–H–A angle limits (deg).
+        distance_cutoff: Max A-D distance.
+        dha_angle_min/max: D-H-A angle limits (deg).
 
     Returns:
         mask: (F, Na, K) boolean
-        distances: (F, Na, K) A–D distances
-        angles: (F, Na, K) D–H–A angles (deg)
+        distances: (F, Na, K) A-D distances
+        angles: (F, Na, K) D-H-A angles (deg)
     """
     acc = lig_coords_f[:, acc_idx, :]
     donors = res_coords_f[:, d_idx, :]
@@ -141,7 +143,7 @@ def hbdonor_frames(
     """Frame-batched hydrogen bond (donor) geometry (inverted).
 
     The distance is measured between donor and acceptor heavy atoms to mirror
-    SingleAngle semantics after role inversion. The angle remains D–H–A in
+    SingleAngle semantics after role inversion. The angle remains D-H-A in
     degrees. Returns (mask, distances, angles) with shapes (F, Nd, Ka).
     """
     donors = lig_coords_f[:, d_idx, :]
@@ -153,7 +155,9 @@ def hbdonor_frames(
     dc = jnp.nextafter(jnp.asarray(distance_cutoff, dists.dtype), jnp.inf)
     dist_ok = dists <= dc
 
-    ang = angle_at_vertex(donors[:, :, None, :], hydrogens[:, :, None, :], acc[:, None, :, :])
+    ang = angle_at_vertex(
+        donors[:, :, None, :], hydrogens[:, :, None, :], acc[:, None, :, :]
+    )
     ang_deg = jnp.degrees(ang)
     min_deg = jnp.nextafter(jnp.asarray(dha_angle_min, ang_deg.dtype), -jnp.inf)
     max_deg = jnp.nextafter(jnp.asarray(dha_angle_max, ang_deg.dtype), jnp.inf)
@@ -178,7 +182,7 @@ def xbacceptor_frames(
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Frame-batched halogen bond (acceptor) geometry.
 
-    Returns (mask, distances[A–X], axd_angles, xar_angles) with shapes (F, Na, K).
+    Returns (mask, distances[A-X], axd_angles, xar_angles) with shapes (F, Na, K).
     """
     acc = lig_coords_f[:, a_idx, :]
     neigh = lig_coords_f[:, r_idx, :]
@@ -225,7 +229,7 @@ def xbdonor_frames(
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Frame-batched halogen bond (donor) geometry (inverted).
 
-    Returns (mask, distances[X–A], axd_angles, xar_angles) with shapes (F, Nx, Ka).
+    Returns (mask, distances[X-A], axd_angles, xar_angles) with shapes (F, Nx, Ka).
     """
     hal = lig_coords_f[:, x_idx, :]
     don = lig_coords_f[:, d_idx, :]
@@ -285,7 +289,7 @@ def _ring_centroids_normals_frames(
         a_hat = a / jnp.clip(jnp.linalg.norm(a, axis=-1, keepdims=True), 1e-8)
         b_hat = b / jnp.clip(jnp.linalg.norm(b, axis=-1, keepdims=True), 1e-8)
         n = jnp.cross(a_hat, b_hat)
-        n = n / jnp.clip(jnp.linalg.norm(n, axis=-1, keepdims=True), 1e-8)
+        n /= jnp.clip(jnp.linalg.norm(n, axis=-1, keepdims=True), 1e-8)
         centroids_list.append(centroid)
         normals_list.append(n)
     if centroids_list:
@@ -307,19 +311,21 @@ def cationpi_frames(
     angle_min: float = 0.0,
     angle_max: float = 30.0,
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-    """Frame-batched Cation–Pi geometry for one orientation (ring vs cation).
+    """Frame-batched Cation-Pi geometry for one orientation (ring vs cation).
 
     Angles are folded into [0, 90] to account for ring-normal sign ambiguity,
     matching ProLIF's ``angle_between_limits(..., ring=True)`` behaviour.
 
     Returns:
         mask: (F, Kr, Kc)
-        distances: (F, Kr, Kc) centroid–cation distances
-        angles: (F, Kr, Kc) folded normal–centroid vector angles (deg)
+        distances: (F, Kr, Kc) centroid-cation distances
+        angles: (F, Kr, Kc) folded normal-centroid vector angles (deg)
     """
     F = int(ring_coords_f.shape[0])
     centroids, normals = _ring_centroids_normals_frames(ring_coords_f, ring_list)
-    cations = cation_coords_f[:, cation_idx, :] if cation_idx.size else jnp.zeros((F, 0, 3))
+    cations = (
+        cation_coords_f[:, cation_idx, :] if cation_idx.size else jnp.zeros((F, 0, 3))
+    )
     if centroids.shape[1] == 0 or cations.shape[1] == 0:
         z = jnp.zeros((F, centroids.shape[1], cations.shape[1]))
         return z.astype(bool), z, z
@@ -406,7 +412,7 @@ def pistacking_frames(
     intersect: bool = False,
     intersect_radius: float = 1.5,
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
-    """Frame-batched Pi-stacking geometry for ring–ring pairs.
+    """Frame-batched Pi-stacking geometry for ring-ring pairs.
 
     When ``intersect=True``, applies ProLIF's EdgeToFace intersection check:
     the line of intersection of the two ring planes must pass within
@@ -414,7 +420,7 @@ def pistacking_frames(
 
     Returns:
         mask: (F, Kl, Kr)
-        distances: (F, Kl, Kr) centroid–centroid distances
+        distances: (F, Kl, Kr) centroid-centroid distances
         plane_angles: (F, Kl, Kr) normals plane angle (deg)
         ncc_angles: (F, Kl, Kr) min of the two normal→centroid angles (deg)
     """
@@ -445,11 +451,14 @@ def pistacking_frames(
 
     mask = dist_ok & pa_ok & ncc_ok
     if intersect:
-        mask = mask & _compute_intersect_check(lc, ln, rc, rn, intersect_radius)
+        mask &= _compute_intersect_check(lc, ln, rc, rn, intersect_radius)
     return mask, dists, pa_deg, ncc_deg
 
 
-def build_actor_masks(lig_mol, residues):
+def build_actor_masks(
+    lig_mol: Any,
+    residues: list[Any],
+) -> tuple[dict[str, jnp.ndarray], dict[str, jnp.ndarray]]:
     """Compute boolean masks for distance-only actor atoms.
 
     Returns ligand and residue masks for Hydrophobic, Cationic, Anionic,
@@ -461,14 +470,14 @@ def build_actor_masks(lig_mol, residues):
     the patterns must be applied to the swapped sides to match ProLIF semantics.
     """
 
-    _INVERTED = frozenset({'Anionic', 'MetalAcceptor'})
+    INVERTED = frozenset({"Anionic", "MetalAcceptor"})
 
     inters = {
-        'Hydrophobic': Hydrophobic(),
-        'Cationic': Cationic(),
-        'Anionic': Anionic(),
-        'MetalDonor': MetalDonor(),
-        'MetalAcceptor': MetalAcceptor(),
+        "Hydrophobic": Hydrophobic(),
+        "Cationic": Cationic(),
+        "Anionic": Anionic(),
+        "MetalDonor": MetalDonor(),
+        "MetalAcceptor": MetalAcceptor(),
     }
 
     N = lig_mol.GetNumAtoms()
@@ -477,7 +486,7 @@ def build_actor_masks(lig_mol, residues):
     lig_masks = {}
     res_masks = {}
     for name, inter in inters.items():
-        inverted = name in _INVERTED
+        inverted = name in INVERTED
         lig_pat = inter.prot_pattern if inverted else inter.lig_pattern
         res_pat = inter.lig_pattern if inverted else inter.prot_pattern
 
@@ -496,14 +505,19 @@ def build_actor_masks(lig_mol, residues):
                 idxs = [mm[0] for mm in pmatches]
                 mm = jnp.zeros((r.GetNumAtoms(),), dtype=bool)
                 mm = mm.at[jnp.array(idxs)].set(True)
-                m = m.at[:r.GetNumAtoms()].set(mm)
+                m = m.at[: r.GetNumAtoms()].set(mm)
             r_rows.append(m)
-        res_masks[name] = jnp.stack(r_rows, axis=0) if r_rows else jnp.zeros((0, 0), dtype=bool)
+        res_masks[name] = (
+            jnp.stack(r_rows, axis=0) if r_rows else jnp.zeros((0, 0), dtype=bool)
+        )
 
     return lig_masks, res_masks
 
 
-def build_angle_indices_rdkit(lig_mol, residues):
+def build_angle_indices_rdkit(
+    lig_mol: Any,
+    residues: list[Any],
+) -> dict[str, dict[str, Any]]:
     """Precompute angle indices using RDKit molecules (internal helper).
 
     This variant derives indices from ProLIF RDKit molecules. It is intended
@@ -521,21 +535,30 @@ def build_angle_indices_rdkit(lig_mol, residues):
     lmatches = lig_mol.GetSubstructMatches(hb_acc.lig_pattern)
     if lmatches:
         hb_acc_idx = [m[0] for m in lmatches]
-    hb_acc_idx = jnp.array(hb_acc_idx, dtype=int) if hb_acc_idx else jnp.zeros((0,), dtype=int)
+    hb_acc_idx = (
+        jnp.array(hb_acc_idx, dtype=int) if hb_acc_idx else jnp.zeros((0,), dtype=int)
+    )
 
     hb_d_rows, hb_h_rows = [], []
     for r in residues:
         pmatches = r.GetSubstructMatches(hb_acc.prot_pattern)
         pairs = []
-        for m in (pmatches or []):
+        for m in pmatches or []:
             if len(m) >= 2:
                 pairs.append((m[0], m[1]))
-        d = jnp.array([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
-        h = jnp.array([p[1] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        d = (
+            jnp.array([p[0] for p in pairs], dtype=int)
+            if pairs
+            else jnp.zeros((0,), dtype=int)
+        )
+        h = (
+            jnp.array([p[1] for p in pairs], dtype=int)
+            if pairs
+            else jnp.zeros((0,), dtype=int)
+        )
         hb_d_rows.append(d)
         hb_h_rows.append(h)
 
-    xb_a_rows, xb_r_rows = [], []
     lmatches = lig_mol.GetSubstructMatches(xb_acc.lig_pattern)
     a = [m[0] for m in lmatches] if lmatches else []
     r = [m[1] for m in lmatches] if lmatches else []
@@ -546,71 +569,110 @@ def build_angle_indices_rdkit(lig_mol, residues):
     for res in residues:
         pmatches = res.GetSubstructMatches(xb_acc.prot_pattern)
         pairs = []
-        for m in (pmatches or []):
+        for m in pmatches or []:
             if len(m) >= 2:
                 pairs.append((m[1], m[0]))
-        x = jnp.array([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
-        d = jnp.array([p[1] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        x = (
+            jnp.array([p[0] for p in pairs], dtype=int)
+            if pairs
+            else jnp.zeros((0,), dtype=int)
+        )
+        d = (
+            jnp.array([p[1] for p in pairs], dtype=int)
+            if pairs
+            else jnp.zeros((0,), dtype=int)
+        )
         xb_x_rows.append(x)
         xb_d_rows.append(d)
 
     lmatches = lig_mol.GetSubstructMatches(hb_don.prot_pattern)
     hb_lig_pairs = []
-    for m in (lmatches or []):
+    for m in lmatches or []:
         if len(m) >= 2:
             hb_lig_pairs.append((m[0], m[1]))
-    hb_lig_d_idx = jnp.array([p[0] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
-    hb_lig_h_idx = jnp.array([p[1] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
+    hb_lig_d_idx = (
+        jnp.array([p[0] for p in hb_lig_pairs], dtype=int)
+        if hb_lig_pairs
+        else jnp.zeros((0,), dtype=int)
+    )
+    hb_lig_h_idx = (
+        jnp.array([p[1] for p in hb_lig_pairs], dtype=int)
+        if hb_lig_pairs
+        else jnp.zeros((0,), dtype=int)
+    )
 
     hb_res_acc_rows = []
     for res in residues:
         pmatches = res.GetSubstructMatches(hb_don.lig_pattern)
-        acc = jnp.array([m[0] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
+        acc = (
+            jnp.array([m[0] for m in (pmatches or [])], dtype=int)
+            if pmatches
+            else jnp.zeros((0,), dtype=int)
+        )
         hb_res_acc_rows.append(acc)
 
     lmatches = lig_mol.GetSubstructMatches(xb_don.lig_pattern)
     xbdon_pairs = []
-    for m in (lmatches or []):
+    for m in lmatches or []:
         if len(m) >= 2:
             xbdon_pairs.append((m[1], m[0]))
-    xbdon_lig_x_idx = jnp.array([p[0] for p in xbdon_pairs], dtype=int) if xbdon_pairs else jnp.zeros((0,), dtype=int)
-    xbdon_lig_d_idx = jnp.array([p[1] for p in xbdon_pairs], dtype=int) if xbdon_pairs else jnp.zeros((0,), dtype=int)
+    xbdon_lig_x_idx = (
+        jnp.array([p[0] for p in xbdon_pairs], dtype=int)
+        if xbdon_pairs
+        else jnp.zeros((0,), dtype=int)
+    )
+    xbdon_lig_d_idx = (
+        jnp.array([p[1] for p in xbdon_pairs], dtype=int)
+        if xbdon_pairs
+        else jnp.zeros((0,), dtype=int)
+    )
 
     xbdon_res_a_rows, xbdon_res_r_rows = [], []
     for res in residues:
         pmatches = res.GetSubstructMatches(xb_don.lig_pattern)
-        a = jnp.array([m[0] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
-        r = jnp.array([m[1] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
-        xbdon_res_a_rows.append(a)
-        xbdon_res_r_rows.append(r)
+        a_idx = (
+            jnp.array([m[0] for m in (pmatches or [])], dtype=int)
+            if pmatches
+            else jnp.zeros((0,), dtype=int)
+        )
+        r_idx = (
+            jnp.array([m[1] for m in (pmatches or [])], dtype=int)
+            if pmatches
+            else jnp.zeros((0,), dtype=int)
+        )
+        xbdon_res_a_rows.append(a_idx)
+        xbdon_res_r_rows.append(r_idx)
 
     return {
-        'hb': {
-            'acc_idx': hb_acc_idx,
-            'res_d_idx': hb_d_rows,
-            'res_h_idx': hb_h_rows,
+        "hb": {
+            "acc_idx": hb_acc_idx,
+            "res_d_idx": hb_d_rows,
+            "res_h_idx": hb_h_rows,
         },
-        'hb_donor': {
-            'lig_d_idx': hb_lig_d_idx,
-            'lig_h_idx': hb_lig_h_idx,
-            'res_a_idx': hb_res_acc_rows,
+        "hb_donor": {
+            "lig_d_idx": hb_lig_d_idx,
+            "lig_h_idx": hb_lig_h_idx,
+            "res_a_idx": hb_res_acc_rows,
         },
-        'xbacc': {
-            'lig_a_idx': xbacc_a_idx,
-            'lig_r_idx': xbacc_r_idx,
-            'res_x_idx': xb_x_rows,
-            'res_d_idx': xb_d_rows,
+        "xbacc": {
+            "lig_a_idx": xbacc_a_idx,
+            "lig_r_idx": xbacc_r_idx,
+            "res_x_idx": xb_x_rows,
+            "res_d_idx": xb_d_rows,
         },
-        'xbdon': {
-            'lig_x_idx': xbdon_lig_x_idx,
-            'lig_d_idx': xbdon_lig_d_idx,
-            'res_a_idx': xbdon_res_a_rows,
-            'res_r_idx': xbdon_res_r_rows,
+        "xbdon": {
+            "lig_x_idx": xbdon_lig_x_idx,
+            "lig_d_idx": xbdon_lig_d_idx,
+            "res_a_idx": xbdon_res_a_rows,
+            "res_r_idx": xbdon_res_r_rows,
         },
     }
 
 
-def build_angle_indices(lig_ag, residue_ags):
+def build_angle_indices(
+    lig_ag: Any,
+    residue_ags: list[Any],
+) -> dict[str, dict[str, Any]]:
     """Build angle indices from AtomGroups for real-frame alignment.
 
     Derives RDKit molecules directly from the provided MDAnalysis AtomGroups
@@ -631,61 +693,83 @@ def build_angle_indices(lig_ag, residue_ags):
     lmatches = lig_mol.GetSubstructMatches(hb_acc.lig_pattern)
     if lmatches:
         hb_acc_idx = [m[0] for m in lmatches]
-    hb_acc_idx = jnp.array(hb_acc_idx, dtype=int) if hb_acc_idx else jnp.zeros((0,), dtype=int)
+    hb_acc_idx = (
+        jnp.array(hb_acc_idx, dtype=int) if hb_acc_idx else jnp.zeros((0,), dtype=int)
+    )
 
     hb_d_rows, hb_h_rows = [], []
     for r in res_mols:
         pmatches = r.GetSubstructMatches(hb_acc.prot_pattern)
         pairs = []
-        for m in (pmatches or []):
+        for m in pmatches or []:
             if len(m) >= 2:
                 pairs.append((m[0], m[1]))
-        d = jnp.array([p[0] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
-        h = jnp.array([p[1] for p in pairs], dtype=int) if pairs else jnp.zeros((0,), dtype=int)
+        d = (
+            jnp.array([p[0] for p in pairs], dtype=int)
+            if pairs
+            else jnp.zeros((0,), dtype=int)
+        )
+        h = (
+            jnp.array([p[1] for p in pairs], dtype=int)
+            if pairs
+            else jnp.zeros((0,), dtype=int)
+        )
         hb_d_rows.append(d)
         hb_h_rows.append(h)
 
     lmatches = lig_mol.GetSubstructMatches(hb_don.prot_pattern)
     hb_lig_pairs = []
-    for m in (lmatches or []):
+    for m in lmatches or []:
         if len(m) >= 2:
             hb_lig_pairs.append((m[0], m[1]))
-    hb_lig_d_idx = jnp.array([p[0] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
-    hb_lig_h_idx = jnp.array([p[1] for p in hb_lig_pairs], dtype=int) if hb_lig_pairs else jnp.zeros((0,), dtype=int)
+    hb_lig_d_idx = (
+        jnp.array([p[0] for p in hb_lig_pairs], dtype=int)
+        if hb_lig_pairs
+        else jnp.zeros((0,), dtype=int)
+    )
+    hb_lig_h_idx = (
+        jnp.array([p[1] for p in hb_lig_pairs], dtype=int)
+        if hb_lig_pairs
+        else jnp.zeros((0,), dtype=int)
+    )
 
     hb_res_acc_rows = []
     for r in res_mols:
         pmatches = r.GetSubstructMatches(hb_don.lig_pattern)
-        acc = jnp.array([m[0] for m in (pmatches or [])], dtype=int) if pmatches else jnp.zeros((0,), dtype=int)
+        acc = (
+            jnp.array([m[0] for m in (pmatches or [])], dtype=int)
+            if pmatches
+            else jnp.zeros((0,), dtype=int)
+        )
         hb_res_acc_rows.append(acc)
 
     return {
-        'hb': {
-            'acc_idx': hb_acc_idx,
-            'res_d_idx': hb_d_rows,
-            'res_h_idx': hb_h_rows,
+        "hb": {
+            "acc_idx": hb_acc_idx,
+            "res_d_idx": hb_d_rows,
+            "res_h_idx": hb_h_rows,
         },
-        'hb_donor': {
-            'lig_d_idx': hb_lig_d_idx,
-            'lig_h_idx': hb_lig_h_idx,
-            'res_a_idx': hb_res_acc_rows,
+        "hb_donor": {
+            "lig_d_idx": hb_lig_d_idx,
+            "lig_h_idx": hb_lig_h_idx,
+            "res_a_idx": hb_res_acc_rows,
         },
-        'xbacc': {
-            'lig_a_idx': jnp.zeros((0,), dtype=int),
-            'lig_r_idx': jnp.zeros((0,), dtype=int),
-            'res_x_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
-            'res_d_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
+        "xbacc": {
+            "lig_a_idx": jnp.zeros((0,), dtype=int),
+            "lig_r_idx": jnp.zeros((0,), dtype=int),
+            "res_x_idx": [jnp.zeros((0,), dtype=int) for _ in res_mols],
+            "res_d_idx": [jnp.zeros((0,), dtype=int) for _ in res_mols],
         },
-        'xbdon': {
-            'lig_x_idx': jnp.zeros((0,), dtype=int),
-            'lig_d_idx': jnp.zeros((0,), dtype=int),
-            'res_a_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
-            'res_r_idx': [jnp.zeros((0,), dtype=int) for _ in res_mols],
+        "xbdon": {
+            "lig_x_idx": jnp.zeros((0,), dtype=int),
+            "lig_d_idx": jnp.zeros((0,), dtype=int),
+            "res_a_idx": [jnp.zeros((0,), dtype=int) for _ in res_mols],
+            "res_r_idx": [jnp.zeros((0,), dtype=int) for _ in res_mols],
         },
     }
 
 
-def build_ring_cation_indices(lig_mol, residues):
+def build_ring_cation_indices(lig_mol: Any, residues: list[Any]) -> dict[str, Any]:
     """Precompute ring and cation indices for ring-based interactions.
 
     Uses ProLIF patterns to find aromatic rings and cations on the ligand and
@@ -710,31 +794,39 @@ def build_ring_cation_indices(lig_mol, residues):
 
     cp = CationPi()
     lmatches = lig_mol.GetSubstructMatches(cp.cation)
-    lig_cations = jnp.array([m[0] for m in lmatches], dtype=int) if lmatches else jnp.zeros((0,), dtype=int)
+    lig_cations = (
+        jnp.array([m[0] for m in lmatches], dtype=int)
+        if lmatches
+        else jnp.zeros((0,), dtype=int)
+    )
     res_cations = []
     for r in residues:
         pm = r.GetSubstructMatches(cp.cation)
-        rc = jnp.array([m[0] for m in pm], dtype=int) if pm else jnp.zeros((0,), dtype=int)
+        rc = (
+            jnp.array([m[0] for m in pm], dtype=int)
+            if pm
+            else jnp.zeros((0,), dtype=int)
+        )
         res_cations.append(rc)
 
     return {
-        'lig_rings': lig_rings,
-        'res_rings': res_rings,
-        'lig_cations': lig_cations,
-        'res_cations': res_cations,
-        'pi': pi,
-        'cp': cp,
+        "lig_rings": lig_rings,
+        "res_rings": res_rings,
+        "lig_cations": lig_cations,
+        "res_cations": res_cations,
+        "pi": pi,
+        "cp": cp,
     }
 
 
 def build_vdw_radii(
-    lig_mol,
-    residues,
+    lig_mol: Any,
+    residues: list[Any],
     *,
-    lig_ag=None,
-    residue_ags=None,
+    lig_ag: Any = None,
+    residue_ags: list[Any] | None = None,
     use_real: bool = False,
-):
+) -> tuple[jnp.ndarray, jnp.ndarray, float]:
     """Build per-atom van der Waals radii arrays aligned with coordinate order.
 
     When ``use_real`` is True, radii are derived from MDAnalysis AtomGroups to
@@ -745,7 +837,7 @@ def build_vdw_radii(
     ProLIF's VdW tolerance.
     """
 
-    def _symbol_from_atom(atom):
+    def _symbol_from_atom(atom: Any) -> str:
         try:
             sym = atom.element
         except Exception:
@@ -753,20 +845,24 @@ def build_vdw_radii(
         if not sym:
             if mda_guessers is not None:
                 try:
-                    sym = mda_guessers.guess_atom_element(getattr(atom, 'name', ''))
+                    sym = mda_guessers.guess_atom_element(getattr(atom, "name", ""))
                 except Exception:
-                    sym = 'C'
+                    sym = "C"
             else:
-                sym = 'C'
+                sym = "C"
         return str(sym).capitalize()
 
     vdw = VdWContact()
 
     if use_real:
         if lig_ag is None or residue_ags is None:
-            raise ValueError("lig_ag and residue_ags must be provided when use_real=True")
+            raise ValueError(
+                "lig_ag and residue_ags must be provided when use_real=True"
+            )
         lig_elems = [_symbol_from_atom(a) for a in lig_ag.atoms]
-        lig_radii = jnp.array([vdw.vdwradii.get(e, 1.7) for e in lig_elems], dtype=float)
+        lig_radii = jnp.array(
+            [vdw.vdwradii.get(e, 1.7) for e in lig_elems], dtype=float
+        )
 
         max_m = max((ag.n_atoms for ag in residue_ags), default=0)
         res_rows = []
@@ -777,11 +873,15 @@ def build_vdw_radii(
                 pad = jnp.zeros((max_m - ag.n_atoms,), dtype=float)
                 row = jnp.concatenate([row, pad], axis=0)
             res_rows.append(row)
-        res_radii = jnp.stack(res_rows, axis=0) if res_rows else jnp.zeros((0, 0), dtype=float)
+        res_radii = (
+            jnp.stack(res_rows, axis=0) if res_rows else jnp.zeros((0, 0), dtype=float)
+        )
     else:
         N = lig_mol.GetNumAtoms()
         lig_elems = [lig_mol.GetAtomWithIdx(i).GetSymbol() for i in range(N)]
-        lig_radii = jnp.array([vdw.vdwradii.get(e, 1.7) for e in lig_elems], dtype=float)
+        lig_radii = jnp.array(
+            [vdw.vdwradii.get(e, 1.7) for e in lig_elems], dtype=float
+        )
 
         max_m = max((r.GetNumAtoms() for r in residues), default=0)
         res_rows = []
@@ -793,12 +893,14 @@ def build_vdw_radii(
                 pad = jnp.zeros((max_m - m,), dtype=float)
                 row = jnp.concatenate([row, pad], axis=0)
             res_rows.append(row)
-        res_radii = jnp.stack(res_rows, axis=0) if res_rows else jnp.zeros((0, 0), dtype=float)
+        res_radii = (
+            jnp.stack(res_rows, axis=0) if res_rows else jnp.zeros((0, 0), dtype=float)
+        )
 
     return lig_radii, res_radii, float(vdw.tolerance)
 
 
-def has_interactions_frames(
+def has_interactions_frames(  # noqa: PLR0912
     lig_f: jnp.ndarray,
     res_f: jnp.ndarray,
     res_valid_mask: jnp.ndarray,
@@ -827,48 +929,66 @@ def has_interactions_frames(
 
     d = pairwise_distances_frames(lig_f, res_f)
 
-    m = (d <= 4.5) & lig_masks['Hydrophobic'][None, None, :, None] & (res_actor_masks['Hydrophobic'] & res_valid_mask)[None, :, None, :]
-    results['Hydrophobic'] = jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
+    m = (
+        (d <= 4.5)
+        & lig_masks["Hydrophobic"][None, None, :, None]
+        & (res_actor_masks["Hydrophobic"] & res_valid_mask)[None, :, None, :]
+    )
+    results["Hydrophobic"] = (
+        jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
+    )
 
-    for k in ('Cationic', 'Anionic'):
-        m = (d <= 4.5) & lig_masks[k][None, None, :, None] & (res_actor_masks[k] & res_valid_mask)[None, :, None, :]
+    for k in ("Cationic", "Anionic"):
+        m = (
+            (d <= 4.5)
+            & lig_masks[k][None, None, :, None]
+            & (res_actor_masks[k] & res_valid_mask)[None, :, None, :]
+        )
         results[k] = jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
 
     lig_radii, res_radii, vdw_tol = vdw_radii
     radii_sum = lig_radii[None, None, :, None] + res_radii[None, :, None, :]
     m = (d <= (radii_sum + vdw_tol)) & res_valid_mask[None, :, None, :]
-    results['VdWContact'] = jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
+    results["VdWContact"] = (
+        jnp.any(m, axis=(2, 3)) if R else jnp.zeros((F, 0), dtype=bool)
+    )
 
-    acc_idx = angle_idx['hb']['acc_idx']
+    acc_idx = angle_idx["hb"]["acc_idx"]
     hb_acc_out = []
     for r_i in range(R):
-        d_idx = angle_idx['hb']['res_d_idx'][r_i]
-        h_idx = angle_idx['hb']['res_h_idx'][r_i]
+        d_idx = angle_idx["hb"]["res_d_idx"][r_i]
+        h_idx = angle_idx["hb"]["res_h_idx"][r_i]
         if acc_idx.size and d_idx.size:
-            _m, _, _ = hbacceptor_frames(lig_f, res_f[:, r_i, :, :], acc_idx, d_idx, h_idx)
-            hb_acc_out.append(jnp.any(_m, axis=(1, 2)))
+            m_, _, _ = hbacceptor_frames(
+                lig_f, res_f[:, r_i, :, :], acc_idx, d_idx, h_idx
+            )
+            hb_acc_out.append(jnp.any(m_, axis=(1, 2)))
         else:
             hb_acc_out.append(jnp.zeros((F,), dtype=bool))
-    results['HBAcceptor'] = jnp.stack(hb_acc_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    results["HBAcceptor"] = (
+        jnp.stack(hb_acc_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    )
 
     hb_don_out = []
-    lig_d = angle_idx['hb_donor']['lig_d_idx']
-    lig_h = angle_idx['hb_donor']['lig_h_idx']
+    lig_d = angle_idx["hb_donor"]["lig_d_idx"]
+    lig_h = angle_idx["hb_donor"]["lig_h_idx"]
     for r_i in range(R):
-        acc = angle_idx['hb_donor']['res_a_idx'][r_i]
+        acc = angle_idx["hb_donor"]["res_a_idx"][r_i]
         if lig_d.size and acc.size:
-            _m, _, _ = hbdonor_frames(lig_f, res_f[:, r_i, :, :], lig_d, lig_h, acc)
-            hb_don_out.append(jnp.any(_m, axis=(1, 2)))
+            m_, _, _ = hbdonor_frames(lig_f, res_f[:, r_i, :, :], lig_d, lig_h, acc)
+            hb_don_out.append(jnp.any(m_, axis=(1, 2)))
         else:
             hb_don_out.append(jnp.zeros((F,), dtype=bool))
-    results['HBDonor'] = jnp.stack(hb_don_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    results["HBDonor"] = (
+        jnp.stack(hb_don_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    )
 
-    lig_rings = ring_idx['lig_rings']
-    res_rings = ring_idx['res_rings']
-    lig_cations = ring_idx['lig_cations']
-    res_cations = ring_idx['res_cations']
-    pi = ring_idx['pi']
-    cp = ring_idx['cp']
+    lig_rings = ring_idx["lig_rings"]
+    res_rings = ring_idx["res_rings"]
+    lig_cations = ring_idx["lig_cations"]
+    res_cations = ring_idx["res_cations"]
+    pi = ring_idx["pi"]
+    cp = ring_idx["cp"]
 
     cationpi_out = []
     picat_out = []
@@ -876,32 +996,45 @@ def has_interactions_frames(
         has_cationpi = jnp.zeros((F,), dtype=bool)
         has_picat = jnp.zeros((F,), dtype=bool)
         if lig_cations.size and len(res_rings[r_i]):
-            _m, _, _ = cationpi_frames(
-                res_f[:, r_i, :, :], res_rings[r_i], lig_f, lig_cations,
+            m_, _, _ = cationpi_frames(
+                res_f[:, r_i, :, :],
+                res_rings[r_i],
+                lig_f,
+                lig_cations,
                 distance_cutoff=float(cp.distance),
                 angle_min=math.degrees(float(cp.angle[0])),
                 angle_max=math.degrees(float(cp.angle[1])),
             )
-            has_cationpi = jnp.any(_m, axis=(1, 2))
+            has_cationpi = jnp.any(m_, axis=(1, 2))
         if len(lig_rings) and res_cations[r_i].size:
-            _m, _, _ = cationpi_frames(
-                lig_f, lig_rings, res_f[:, r_i, :, :], res_cations[r_i],
+            m_, _, _ = cationpi_frames(
+                lig_f,
+                lig_rings,
+                res_f[:, r_i, :, :],
+                res_cations[r_i],
                 distance_cutoff=float(cp.distance),
                 angle_min=math.degrees(float(cp.angle[0])),
                 angle_max=math.degrees(float(cp.angle[1])),
             )
-            has_picat = jnp.any(_m, axis=(1, 2))
+            has_picat = jnp.any(m_, axis=(1, 2))
         cationpi_out.append(has_cationpi)
         picat_out.append(has_picat)
-    results['CationPi'] = jnp.stack(cationpi_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
-    results['PiCation'] = jnp.stack(picat_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    results["CationPi"] = (
+        jnp.stack(cationpi_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    )
+    results["PiCation"] = (
+        jnp.stack(picat_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    )
 
     ps_out = []
     for r_i in range(R):
         if len(lig_rings) and len(res_rings[r_i]):
             ftf = pi.ftf
             mF, _, _, _ = pistacking_frames(
-                lig_f, lig_rings, res_f[:, r_i, :, :], res_rings[r_i],
+                lig_f,
+                lig_rings,
+                res_f[:, r_i, :, :],
+                res_rings[r_i],
                 distance_cutoff=float(ftf.distance),
                 plane_angle_min=math.degrees(float(ftf.plane_angle[0])),
                 plane_angle_max=math.degrees(float(ftf.plane_angle[1])),
@@ -910,7 +1043,10 @@ def has_interactions_frames(
             )
             etf = pi.etf
             mE, _, _, _ = pistacking_frames(
-                lig_f, lig_rings, res_f[:, r_i, :, :], res_rings[r_i],
+                lig_f,
+                lig_rings,
+                res_f[:, r_i, :, :],
+                res_rings[r_i],
                 distance_cutoff=float(etf.distance),
                 plane_angle_min=math.degrees(float(etf.plane_angle[0])),
                 plane_angle_max=math.degrees(float(etf.plane_angle[1])),
@@ -922,7 +1058,9 @@ def has_interactions_frames(
             ps_out.append(jnp.any(mF | mE, axis=(1, 2)))
         else:
             ps_out.append(jnp.zeros((F,), dtype=bool))
-    results['PiStacking'] = jnp.stack(ps_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    results["PiStacking"] = (
+        jnp.stack(ps_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+    )
 
     if R and vicinity_cutoff is not None:
         masked_d = jnp.where(res_valid_mask[None, :, None, :], d, jnp.inf)
@@ -942,7 +1080,7 @@ def prepare_for_device(
     angle_idx: dict,
     ring_idx: dict,
     vdw_radii: tuple,
-    device: str = 'cpu',
+    device: str = "cpu",
 ) -> tuple:
     """Move frame-batched, small metadata arrays to a target device.
 
@@ -963,51 +1101,90 @@ def prepare_for_device(
         Tuple of all inputs moved to the specified device.
         Returns unchanged inputs if device='cpu' or no GPU available.
     """
-    if device != 'gpu':
-        return lig_f, res_f, res_valid_mask, lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+    if device != "gpu":
+        return (
+            lig_f,
+            res_f,
+            res_valid_mask,
+            lig_masks,
+            res_actor_masks,
+            angle_idx,
+            ring_idx,
+            vdw_radii,
+        )
 
-    gpus = jax.devices('gpu')
+    gpus = jax.devices("gpu")
     if not gpus:
-        return lig_f, res_f, res_valid_mask, lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+        return (
+            lig_f,
+            res_f,
+            res_valid_mask,
+            lig_masks,
+            res_actor_masks,
+            angle_idx,
+            ring_idx,
+            vdw_radii,
+        )
 
     dev = gpus[0]
 
     res_valid_mask = jax.device_put(res_valid_mask, device=dev)
-    lig_masks = jax.tree_util.tree_map(lambda x: jax.device_put(x, device=dev), lig_masks)
-    res_actor_masks = jax.tree_util.tree_map(lambda x: jax.device_put(x, device=dev), res_actor_masks)
+    lig_masks = jax.tree_util.tree_map(
+        lambda x: jax.device_put(x, device=dev), lig_masks
+    )
+    res_actor_masks = jax.tree_util.tree_map(
+        lambda x: jax.device_put(x, device=dev), res_actor_masks
+    )
 
     angle_idx = {
-        'hb': {
-            'acc_idx': jax.device_put(angle_idx['hb']['acc_idx'], device=dev),
-            'res_d_idx': [jax.device_put(a, device=dev) for a in angle_idx['hb']['res_d_idx']],
-            'res_h_idx': [jax.device_put(a, device=dev) for a in angle_idx['hb']['res_h_idx']],
+        "hb": {
+            "acc_idx": jax.device_put(angle_idx["hb"]["acc_idx"], device=dev),
+            "res_d_idx": [
+                jax.device_put(a, device=dev) for a in angle_idx["hb"]["res_d_idx"]
+            ],
+            "res_h_idx": [
+                jax.device_put(a, device=dev) for a in angle_idx["hb"]["res_h_idx"]
+            ],
         },
-        'hb_donor': {
-            'lig_d_idx': jax.device_put(angle_idx['hb_donor']['lig_d_idx'], device=dev),
-            'lig_h_idx': jax.device_put(angle_idx['hb_donor']['lig_h_idx'], device=dev),
-            'res_a_idx': [jax.device_put(a, device=dev) for a in angle_idx['hb_donor']['res_a_idx']],
+        "hb_donor": {
+            "lig_d_idx": jax.device_put(angle_idx["hb_donor"]["lig_d_idx"], device=dev),
+            "lig_h_idx": jax.device_put(angle_idx["hb_donor"]["lig_h_idx"], device=dev),
+            "res_a_idx": [
+                jax.device_put(a, device=dev)
+                for a in angle_idx["hb_donor"]["res_a_idx"]
+            ],
         },
-        'xbacc': {
-            'lig_a_idx': jax.device_put(angle_idx['xbacc']['lig_a_idx'], device=dev),
-            'lig_r_idx': jax.device_put(angle_idx['xbacc']['lig_r_idx'], device=dev),
-            'res_x_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbacc']['res_x_idx']],
-            'res_d_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbacc']['res_d_idx']],
+        "xbacc": {
+            "lig_a_idx": jax.device_put(angle_idx["xbacc"]["lig_a_idx"], device=dev),
+            "lig_r_idx": jax.device_put(angle_idx["xbacc"]["lig_r_idx"], device=dev),
+            "res_x_idx": [
+                jax.device_put(a, device=dev) for a in angle_idx["xbacc"]["res_x_idx"]
+            ],
+            "res_d_idx": [
+                jax.device_put(a, device=dev) for a in angle_idx["xbacc"]["res_d_idx"]
+            ],
         },
-        'xbdon': {
-            'lig_x_idx': jax.device_put(angle_idx['xbdon']['lig_x_idx'], device=dev),
-            'lig_d_idx': jax.device_put(angle_idx['xbdon']['lig_d_idx'], device=dev),
-            'res_a_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbdon']['res_a_idx']],
-            'res_r_idx': [jax.device_put(a, device=dev) for a in angle_idx['xbdon']['res_r_idx']],
+        "xbdon": {
+            "lig_x_idx": jax.device_put(angle_idx["xbdon"]["lig_x_idx"], device=dev),
+            "lig_d_idx": jax.device_put(angle_idx["xbdon"]["lig_d_idx"], device=dev),
+            "res_a_idx": [
+                jax.device_put(a, device=dev) for a in angle_idx["xbdon"]["res_a_idx"]
+            ],
+            "res_r_idx": [
+                jax.device_put(a, device=dev) for a in angle_idx["xbdon"]["res_r_idx"]
+            ],
         },
     }
 
     ring_idx = {
-        'lig_rings': [jax.device_put(a, device=dev) for a in ring_idx['lig_rings']],
-        'res_rings': [[jax.device_put(a, device=dev) for a in rr] for rr in ring_idx['res_rings']],
-        'lig_cations': jax.device_put(ring_idx['lig_cations'], device=dev),
-        'res_cations': [jax.device_put(a, device=dev) for a in ring_idx['res_cations']],
-        'pi': ring_idx['pi'],
-        'cp': ring_idx['cp'],
+        "lig_rings": [jax.device_put(a, device=dev) for a in ring_idx["lig_rings"]],
+        "res_rings": [
+            [jax.device_put(a, device=dev) for a in rr] for rr in ring_idx["res_rings"]
+        ],
+        "lig_cations": jax.device_put(ring_idx["lig_cations"], device=dev),
+        "res_cations": [jax.device_put(a, device=dev) for a in ring_idx["res_cations"]],
+        "pi": ring_idx["pi"],
+        "cp": ring_idx["cp"],
     }
 
     lr, rr, vdw_tol = vdw_radii
@@ -1017,16 +1194,25 @@ def prepare_for_device(
         vdw_tol,
     )
 
-    return lig_f, res_f, res_valid_mask, lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+    return (
+        lig_f,
+        res_f,
+        res_valid_mask,
+        lig_masks,
+        res_actor_masks,
+        angle_idx,
+        ring_idx,
+        vdw_radii,
+    )
 
 
-def get_gpu_device():
+def get_gpu_device() -> Any | None:
     """Return the first GPU device if available, else None.
 
     Safe on CPU-only installs where requesting 'gpu' would raise.
     """
     try:
-        gpus = jax.devices('gpu')
+        gpus = jax.devices("gpu")
     except Exception:
         return None
     return gpus[0] if gpus else None
@@ -1053,13 +1239,17 @@ def get_gpu_memory_info() -> tuple[float, float] | None:
             pass
 
     try:
-        out = subprocess.check_output([
-            'nvidia-smi',
-            '--query-gpu=memory.free,memory.total',
-            '--format=csv,noheader,nounits'
-        ], stderr=subprocess.STDOUT, text=True)
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.free,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
         line = out.strip().splitlines()[0]
-        cols = [c.strip() for c in line.split(',')]
+        cols = [c.strip() for c in line.split(",")]
         free_mb = float(cols[0])
         total_mb = float(cols[1])
         return free_mb, total_mb
@@ -1075,7 +1265,7 @@ def estimate_memory_per_frame(
     """Estimate GPU memory usage per frame in bytes.
 
     This is a rough estimate accounting for:
-        - Distance matrices: R × N × M × 4 bytes
+        - Distance matrices: R x N x M x 4 bytes
         - Intermediate arrays and masks
         - JAX overhead multiplier (~3x for JIT buffers)
 
@@ -1124,7 +1314,7 @@ def calculate_chunk_size(
         mem = get_gpu_memory_info()
         if mem is None:
             return 1000
-        available_memory_mb, total_mb = mem[0], mem[1]
+        available_memory_mb = mem[0]
 
     bytes_per_frame = estimate_memory_per_frame(
         n_ligand_atoms, n_residues, max_residue_atoms
@@ -1133,9 +1323,7 @@ def calculate_chunk_size(
     usable_bytes = available_memory_mb * 1024 * 1024 * memory_fraction
     chunk_size = int(usable_bytes / bytes_per_frame)
 
-    chunk_size = max(1, min(chunk_size, 10000))
-
-    return chunk_size
+    return max(1, min(chunk_size, 10000))
 
 
 def chunked_has_interactions_frames(
@@ -1178,7 +1366,7 @@ def chunked_has_interactions_frames(
 
     dev = get_gpu_device()
 
-    all_results = []
+    all_results: list[dict[str, jnp.ndarray]] = []
     for i in range(0, F, chunk_size):
         j = min(i + chunk_size, F)
 
@@ -1190,18 +1378,24 @@ def chunked_has_interactions_frames(
             chunk_res = res_f[i:j]
 
         chunk_result = has_interactions_frames(
-            chunk_lig, chunk_res, res_valid_mask,
-            lig_masks, res_actor_masks, angle_idx, ring_idx, vdw_radii
+            chunk_lig,
+            chunk_res,
+            res_valid_mask,
+            lig_masks,
+            res_actor_masks,
+            angle_idx,
+            ring_idx,
+            vdw_radii,
         )
 
-        chunk_result = jax.device_get(chunk_result)
-        all_results.append(chunk_result)
+        chunk_result_host = jax.device_get(chunk_result)
+        all_results.append({k: jnp.asarray(v) for k, v in chunk_result_host.items()})
 
     if len(all_results) == 1:
         return all_results[0]
 
     combined = {}
-    for key in all_results[0].keys():
+    for key in all_results[0]:
         combined[key] = jnp.concatenate([r[key] for r in all_results], axis=0)
 
     return combined

--- a/prolif/interactions/_jax/framebatch.py
+++ b/prolif/interactions/_jax/framebatch.py
@@ -1,17 +1,4 @@
-"""
-Frame-batched JAX helpers for MD trajectories.
-
-This module provides minimal, safe utilities to vectorize geometry across
-many frames while keeping indices fixed (SMARTS done once per system).
-
-Design goals:
-- Avoid residue-batched complexity (no per-residue index threading/padding).
-- Keep shapes stable across frames to enable JIT specialization.
-- Only implement clear wins; leave angles to the integration layer for now.
-
-API stability: experimental. Functions here are intentionally small and
-focused to avoid future breakage.
-"""
+"""Frame-batched helpers for JAX interaction calculations."""
 
 from __future__ import annotations
 
@@ -266,10 +253,6 @@ def _ring_centroids_normals_frames(
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Compute ring centroids and normals across frames for a list of rings.
 
-    Normals are computed using the same method as ProLIF's
-    ``get_ring_normal_vector``: cross product of unit vectors from the centroid
-    to the first two ring atoms.
-
     Args:
         coords_f: (F, N, 3) coordinates per frame
         rings: list of index arrays (variable ring sizes allowed)
@@ -313,8 +296,7 @@ def cationpi_frames(
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Frame-batched Cation-Pi geometry for one orientation (ring vs cation).
 
-    Angles are folded into [0, 90] to account for ring-normal sign ambiguity,
-    matching ProLIF's ``angle_between_limits(..., ring=True)`` behaviour.
+    Angles are folded into [0, 90] to account for ring-normal sign ambiguity.
 
     Returns:
         mask: (F, Kr, Kc)
@@ -349,11 +331,7 @@ def _compute_intersect_check(
     rn: jnp.ndarray,
     intersect_radius: float,
 ) -> jnp.ndarray:
-    """Check if the ring-plane intersection line passes within radius of a centroid.
-
-    Replicates ProLIF's _get_intersect_point logic: finds the point on the
-    intersection line of the two ring planes closest to the ligand centroid,
-    then checks if that point is within intersect_radius of either centroid.
+    """Check whether ring-plane intersection geometry passes the radius criterion.
 
     Args:
         lc: (F, Kl, 3) ligand ring centroids.
@@ -414,9 +392,8 @@ def pistacking_frames(
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """Frame-batched Pi-stacking geometry for ring-ring pairs.
 
-    When ``intersect=True``, applies ProLIF's EdgeToFace intersection check:
-    the line of intersection of the two ring planes must pass within
-    ``intersect_radius`` of at least one centroid.
+    When ``intersect=True``, the ring-plane intersection distance criterion
+    is applied with ``intersect_radius``.
 
     Returns:
         mask: (F, Kl, Kr)
@@ -462,12 +439,11 @@ def build_actor_masks(
     """Compute boolean masks for distance-only actor atoms.
 
     Returns ligand and residue masks for Hydrophobic, Cationic, Anionic,
-    MetalDonor, and MetalAcceptor SMARTS patterns using ProLIF interactions.
-    Residue masks are padded to a common length across residues.
+    MetalDonor, and MetalAcceptor SMARTS patterns. Residue masks are padded
+    to a common length across residues.
 
-    For interactions created via ``invert_role`` (Anionic, MetalAcceptor), the
-    stored lig_pattern/prot_pattern labels refer to the parent class roles, so
-    the patterns must be applied to the swapped sides to match ProLIF semantics.
+    For inverted interactions (Anionic, MetalAcceptor), ligand and residue
+    patterns are swapped before matching.
     """
 
     INVERTED = frozenset({"Anionic", "MetalAcceptor"})
@@ -518,13 +494,7 @@ def build_angle_indices_rdkit(
     lig_mol: Any,
     residues: list[Any],
 ) -> dict[str, dict[str, Any]]:
-    """Precompute angle indices using RDKit molecules (internal helper).
-
-    This variant derives indices from ProLIF RDKit molecules. It is intended
-    for single-frame RDKit workflows. For real trajectories, prefer
-    ``build_angle_indices`` which derives indices from AtomGroups to align with
-    coordinate order.
-    """
+    """Build angle-index tables from RDKit molecules."""
 
     hb_acc = HBAcceptor()
     hb_don = HBDonor()
@@ -673,15 +643,9 @@ def build_angle_indices(
     lig_ag: Any,
     residue_ags: list[Any],
 ) -> dict[str, dict[str, Any]]:
-    """Build angle indices from AtomGroups for real-frame alignment.
+    """Build angle-index tables from MDAnalysis AtomGroups.
 
-    Derives RDKit molecules directly from the provided MDAnalysis AtomGroups
-    so that returned indices use the same atom ordering as the coordinate
-    arrays built from those groups.
-
-    Returns a dict with the same structure as the RDKit-based variant for the
-    hydrogen-bond orientation pairs. Halogen-bond entries are returned as empty
-    arrays for API completeness.
+    Returns the same key structure as :func:`build_angle_indices_rdkit`.
     """
 
     lig_mol = prolif.Molecule.from_mda(lig_ag)
@@ -770,11 +734,7 @@ def build_angle_indices(
 
 
 def build_ring_cation_indices(lig_mol: Any, residues: list[Any]) -> dict[str, Any]:
-    """Precompute ring and cation indices for ring-based interactions.
-
-    Uses ProLIF patterns to find aromatic rings and cations on the ligand and
-    per residue; returns lists of ring index arrays and arrays of cation indices.
-    """
+    """Build ring and cation index tables for ring-based interactions."""
 
     pi = PiStacking()
     ftf = FaceToFace()
@@ -833,8 +793,8 @@ def build_vdw_radii(
     match the coordinate ordering in real-frame mode. Otherwise, radii are
     derived from RDKit molecules to match duplicate-frame mode.
 
-    Returns ligand radii (N,), residue radii (R, M) padded to max M, and
-    ProLIF's VdW tolerance.
+    Returns ligand radii (N,), residue radii (R, M) padded to max M, and the
+    VdW tolerance used in contact checks.
     """
 
     def _symbol_from_atom(atom: Any) -> str:
@@ -920,8 +880,7 @@ def has_interactions_frames(  # noqa: PLR0912
     Args:
         vicinity_cutoff: Per-frame minimum atom-atom distance cutoff. Any
             (frame, residue) pair where the closest atom-atom distance exceeds
-            this value is masked to False, matching ProLIF's vicinity_cutoff
-            behaviour. Defaults to 6.0 to match ProLIF's default.
+            this value is masked to False. Defaults to 6.0.
     """
     F = int(lig_f.shape[0])
     R = int(res_f.shape[1]) if res_f.ndim == 4 else 0

--- a/prolif/interactions/_jax/framebatch.py
+++ b/prolif/interactions/_jax/framebatch.py
@@ -807,12 +807,19 @@ def has_interactions_frames(
     angle_idx: dict,
     ring_idx: dict,
     vdw_radii: tuple,
+    vicinity_cutoff: float = 6.0,
 ) -> dict[str, jnp.ndarray]:
     """Evaluate nine interactions across frames and residues, returning booleans.
 
     Returns a mapping name → (F, R) boolean arrays for:
     Hydrophobic, Cationic, Anionic, VdWContact, HBAcceptor, HBDonor,
     PiStacking, CationPi, PiCation.
+
+    Args:
+        vicinity_cutoff: Per-frame minimum atom-atom distance cutoff. Any
+            (frame, residue) pair where the closest atom-atom distance exceeds
+            this value is masked to False, matching ProLIF's vicinity_cutoff
+            behaviour. Defaults to 6.0 to match ProLIF's default.
     """
     F = int(lig_f.shape[0])
     R = int(res_f.shape[1]) if res_f.ndim == 4 else 0
@@ -916,6 +923,12 @@ def has_interactions_frames(
         else:
             ps_out.append(jnp.zeros((F,), dtype=bool))
     results['PiStacking'] = jnp.stack(ps_out, axis=1) if R else jnp.zeros((F, 0), dtype=bool)
+
+    if R and vicinity_cutoff is not None:
+        masked_d = jnp.where(res_valid_mask[None, :, None, :], d, jnp.inf)
+        min_dist = masked_d.min(axis=(2, 3))
+        vicinity_mask = min_dist <= vicinity_cutoff
+        results = {k: v & vicinity_mask for k, v in results.items()}
 
     return results
 

--- a/prolif/interactions/_jax/integration.py
+++ b/prolif/interactions/_jax/integration.py
@@ -1,11 +1,4 @@
-"""
-JAX-accelerated interaction detection integrated with ProLIF SMARTS matching.
-
-This module provides JAX-accelerated versions of ProLIF interactions that:
-1. Use ProLIF/RDKit for SMARTS pattern matching (chemistry)
-2. Use JAX for batched geometric calculations (distance, angles)
-
-"""
+"""Interaction detection helpers that combine SMARTS matching with JAX geometry."""
 
 from collections.abc import Iterator
 from itertools import product
@@ -39,11 +32,7 @@ def compute_distances_batch(
 
 
 class JAXDistanceMixin:
-    """Mixin to accelerate Distance-based interactions with JAX.
-
-    This mixin overrides the detect method to batch distance calculations
-    while still using ProLIF's SMARTS matching.
-    """
+    """Mixin providing batched distance checks for distance interactions."""
 
     lig_pattern: Any
     prot_pattern: Any
@@ -86,8 +75,6 @@ def detect_distance_batch(
     residues: list[Any],
 ) -> list[list[dict[str, Any]]]:
     """Batch detect Distance interactions across multiple residues.
-
-    This is the main entry point for JAX-accelerated interaction detection.
 
     Args:
         interaction: A Distance-based interaction instance (Hydrophobic, Cationic, etc.)
@@ -217,17 +204,7 @@ def _has_singleangle_interaction(
     residues: list[Any],
     is_inverted: bool,
 ) -> list[bool]:
-    """Check SingleAngle-based interactions (HBAcceptor, HBDonor).
-
-    For SingleAngle:
-    - lig_pattern matches L1 (single atom)
-    - prot_pattern matches P1-P2 (two atoms for angle)
-    - Distance is L1 to P1 or P2
-    - Angle is P1-P2...L1
-
-    For inverted (HBDonor):
-    - Roles are swapped: ligand has P1-P2, protein has L1
-    """
+    """Check single-angle interactions for each residue."""
     results = []
     for res in residues:
         if is_inverted:
@@ -267,15 +244,7 @@ def _has_doubleangle_interaction(
     residues: list[Any],
     is_inverted: bool,
 ) -> list[bool]:
-    """Check DoubleAngle-based interactions (XBAcceptor, XBDonor).
-
-    For DoubleAngle:
-    - lig_pattern matches L1-L2 (two atoms)
-    - prot_pattern matches P1-P2 (two atoms)
-
-    For inverted (XBDonor):
-    - Roles are swapped
-    """
+    """Check double-angle interactions for each residue."""
     results = []
     for res in residues:
         if is_inverted:

--- a/prolif/interactions/_jax/integration.py
+++ b/prolif/interactions/_jax/integration.py
@@ -1,0 +1,457 @@
+"""
+JAX-accelerated interaction detection integrated with ProLIF SMARTS matching.
+
+This module provides JAX-accelerated versions of ProLIF interactions that:
+1. Use ProLIF/RDKit for SMARTS pattern matching (chemistry)
+2. Use JAX for batched geometric calculations (distance, angles)
+
+"""
+
+from itertools import product
+from math import radians, degrees
+from typing import Iterator
+
+import jax.numpy as jnp
+from rdkit.Geometry import Point3D
+
+from prolif.interactions.base import Distance, SingleAngle, DoubleAngle, BasePiStacking
+from prolif.utils import angle_between_limits, get_centroid, get_ring_normal_vector
+from .primitives import pairwise_distances, angle_at_vertex, angle_between_vectors
+
+
+def compute_distances_batch(
+    lig_coords,
+    prot_coords,
+) -> jnp.ndarray:
+    """Compute pairwise distances between two atom sets using JAX.
+
+    Args:
+        lig_coords: (N, 3) coordinates array (array-like); converted to `jnp.ndarray`.
+        prot_coords: (M, 3) coordinates array (array-like); converted to `jnp.ndarray`.
+
+    Returns:
+        (N, M) `jnp.ndarray` of Euclidean distances.
+    """
+    lig_jax = jnp.asarray(lig_coords)
+    prot_jax = jnp.asarray(prot_coords)
+    return pairwise_distances(lig_jax, prot_jax)
+
+
+class JAXDistanceMixin:
+    """Mixin to accelerate Distance-based interactions with JAX.
+
+    This mixin overrides the detect method to batch distance calculations
+    while still using ProLIF's SMARTS matching.
+    """
+
+    def detect(self, lig_res, prot_res) -> Iterator:
+        """Detect interactions using JAX-accelerated distance calculation."""
+        lig_matches = lig_res.GetSubstructMatches(self.lig_pattern)
+        prot_matches = prot_res.GetSubstructMatches(self.prot_pattern)
+
+        if not (lig_matches and prot_matches):
+            return
+
+        lig_indices = [m[0] for m in lig_matches]
+        prot_indices = [m[0] for m in prot_matches]
+
+        lig_coords = lig_res.xyz[lig_indices]
+        prot_coords = prot_res.xyz[prot_indices]
+
+        distances = compute_distances_batch(lig_coords, prot_coords)
+
+        within_threshold = distances <= self.distance
+
+        for i, lig_match in enumerate(lig_matches):
+            for j, prot_match in enumerate(prot_matches):
+                if within_threshold[i, j]:
+                    yield self.metadata(
+                        lig_res,
+                        prot_res,
+                        lig_match,
+                        prot_match,
+                        distance=float(distances[i, j]),
+                    )
+
+
+def detect_distance_batch(
+    interaction,
+    lig_res,
+    residues: list,
+) -> list[list[dict]]:
+    """Batch detect Distance interactions across multiple residues.
+
+    This is the main entry point for JAX-accelerated interaction detection.
+
+    Args:
+        interaction: A Distance-based interaction instance (Hydrophobic, Cationic, etc.)
+        lig_res: Ligand residue
+        residues: List of protein residues to check
+
+    Returns:
+        List of lists, one per residue, containing interaction metadata dicts.
+    """
+    lig_matches = lig_res.GetSubstructMatches(interaction.lig_pattern)
+    if not lig_matches:
+        return [[] for _ in residues]
+
+    lig_indices = [m[0] for m in lig_matches]
+    lig_coords = lig_res.xyz[lig_indices]
+
+    results = []
+
+    all_prot_data = []
+    for res in residues:
+        prot_matches = res.GetSubstructMatches(interaction.prot_pattern)
+        if prot_matches:
+            prot_indices = [m[0] for m in prot_matches]
+            prot_coords = res.xyz[prot_indices]
+            all_prot_data.append((prot_matches, prot_coords))
+        else:
+            all_prot_data.append(([], None))
+
+    for idx, (prot_matches, prot_coords) in enumerate(all_prot_data):
+        res_results = []
+
+        if prot_matches:
+            distances = compute_distances_batch(lig_coords, prot_coords)
+            within_threshold = distances <= interaction.distance
+
+            for i, lig_match in enumerate(lig_matches):
+                for j, prot_match in enumerate(prot_matches):
+                    if within_threshold[i, j]:
+                        res_results.append(
+                            interaction.metadata(
+                                lig_res,
+                                residues[idx],
+                                lig_match,
+                                prot_match,
+                                distance=float(distances[i, j]),
+                            )
+                        )
+
+        results.append(res_results)
+
+    return results
+
+
+def _is_inverted_interaction(interaction) -> bool:
+    """Check if an interaction was created with invert_role."""
+    name = type(interaction).__name__
+    return name in ('HBDonor', 'XBDonor', 'Anionic', 'PiCation', 'MetalAcceptor')
+
+
+def _get_interaction_type(interaction) -> str:
+    """Determine the base type of an interaction."""
+    cls = type(interaction)
+    name = cls.__name__
+
+    if name == 'VdWContact':
+        return 'vdwcontact'
+    if name == 'PiStacking':
+        return 'pistacking_composite'
+    if name in ('FaceToFace', 'EdgeToFace'):
+        return 'pistacking'
+    if name in ('CationPi', 'PiCation'):
+        return 'cationpi'
+
+    if isinstance(interaction, BasePiStacking):
+        return 'pistacking'
+    if hasattr(interaction, 'pi_ring') and hasattr(interaction, 'cation'):
+        return 'cationpi'
+    if isinstance(interaction, DoubleAngle):
+        return 'doubleangle'
+    if isinstance(interaction, SingleAngle):
+        return 'singleangle'
+    if isinstance(interaction, Distance):
+        return 'distance'
+
+    return 'distance'
+
+
+def _has_distance_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+    """Check Distance-based interactions."""
+    if is_inverted:
+        lig_pattern = interaction.prot_pattern
+        prot_pattern = interaction.lig_pattern
+    else:
+        lig_pattern = interaction.lig_pattern
+        prot_pattern = interaction.prot_pattern
+
+    lig_matches = lig_res.GetSubstructMatches(lig_pattern)
+    if not lig_matches:
+        return [False] * len(residues)
+
+    lig_indices = [m[0] for m in lig_matches]
+    lig_coords = lig_res.xyz[lig_indices]
+
+    results = []
+    for res in residues:
+        prot_matches = res.GetSubstructMatches(prot_pattern)
+        if not prot_matches:
+            results.append(False)
+            continue
+
+        prot_indices = [m[0] for m in prot_matches]
+        prot_coords = res.xyz[prot_indices]
+        distances = compute_distances_batch(lig_coords, prot_coords)
+        results.append(bool((distances <= interaction.distance).any()))
+
+    return results
+
+
+def _has_singleangle_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+    """Check SingleAngle-based interactions (HBAcceptor, HBDonor).
+
+    For SingleAngle:
+    - lig_pattern matches L1 (single atom)
+    - prot_pattern matches P1-P2 (two atoms for angle)
+    - Distance is L1 to P1 or P2
+    - Angle is P1-P2...L1
+
+    For inverted (HBDonor):
+    - Roles are swapped: ligand has P1-P2, protein has L1
+    """
+    results = []
+    for res in residues:
+        if is_inverted:
+            prot_matches = lig_res.GetSubstructMatches(interaction.prot_pattern)
+            lig_matches = res.GetSubstructMatches(interaction.lig_pattern)
+            prot_xyz, lig_xyz = lig_res.xyz, res.xyz
+        else:
+            lig_matches = lig_res.GetSubstructMatches(interaction.lig_pattern)
+            prot_matches = res.GetSubstructMatches(interaction.prot_pattern)
+            lig_xyz, prot_xyz = lig_res.xyz, res.xyz
+
+        if not (lig_matches and prot_matches):
+            results.append(False)
+            continue
+
+        found = False
+        for lig_match, prot_match in product(lig_matches, prot_matches):
+            l1 = Point3D(*lig_xyz[lig_match[0]])
+            p1 = Point3D(*prot_xyz[prot_match[0]])
+            p2 = Point3D(*prot_xyz[prot_match[1]])
+            dist = interaction._measure_distance(l1, p1, p2)
+            if dist <= interaction.distance:
+                p2p1 = p2.DirectionVector(p1)
+                p2l1 = p2.DirectionVector(l1)
+                angle = p2p1.AngleTo(p2l1)
+                if angle_between_limits(angle, *interaction.angle):
+                    found = True
+                    break
+        results.append(found)
+
+    return results
+
+
+def _has_doubleangle_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+    """Check DoubleAngle-based interactions (XBAcceptor, XBDonor).
+
+    For DoubleAngle:
+    - lig_pattern matches L1-L2 (two atoms)
+    - prot_pattern matches P1-P2 (two atoms)
+
+    For inverted (XBDonor):
+    - Roles are swapped
+    """
+    results = []
+    for res in residues:
+        if is_inverted:
+            prot_matches = lig_res.GetSubstructMatches(interaction.prot_pattern)
+            lig_matches = res.GetSubstructMatches(interaction.lig_pattern)
+            prot_xyz, lig_xyz = lig_res.xyz, res.xyz
+        else:
+            lig_matches = lig_res.GetSubstructMatches(interaction.lig_pattern)
+            prot_matches = res.GetSubstructMatches(interaction.prot_pattern)
+            lig_xyz, prot_xyz = lig_res.xyz, res.xyz
+
+        if not (lig_matches and prot_matches):
+            results.append(False)
+            continue
+
+        found = False
+        for lig_match, prot_match in product(lig_matches, prot_matches):
+            l1 = Point3D(*lig_xyz[lig_match[0]])
+            l2 = Point3D(*lig_xyz[lig_match[1]])
+            p1 = Point3D(*prot_xyz[prot_match[0]])
+            p2 = Point3D(*prot_xyz[prot_match[1]])
+            dist = interaction._measure_distance(l1, l2, p1, p2)
+            if dist <= interaction.distance:
+                p2p1 = p2.DirectionVector(p1)
+                p2l1 = p2.DirectionVector(l1)
+                l1p2p1 = p2p1.AngleTo(p2l1)
+                if angle_between_limits(l1p2p1, *interaction.L1P2P1_angle):
+                    l1p2 = l1.DirectionVector(p2)
+                    l1l2 = l1.DirectionVector(l2)
+                    l2l1p2 = l1p2.AngleTo(l1l2)
+                    if angle_between_limits(l2l1p2, *interaction.L2L1P2_angle):
+                        found = True
+                        break
+        results.append(found)
+
+    return results
+
+
+def _has_cationpi_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+    """Check CationPi/PiCation interactions."""
+    results = []
+    for res in residues:
+        if is_inverted:
+            ring_matches = []
+            for pi_ring in interaction.pi_ring:
+                ring_matches.extend(lig_res.GetSubstructMatches(pi_ring))
+            cation_matches = res.GetSubstructMatches(interaction.cation)
+            ring_xyz, cation_xyz = lig_res.xyz, res.xyz
+        else:
+            cation_matches = lig_res.GetSubstructMatches(interaction.cation)
+            ring_matches = []
+            for pi_ring in interaction.pi_ring:
+                ring_matches.extend(res.GetSubstructMatches(pi_ring))
+            ring_xyz, cation_xyz = res.xyz, lig_res.xyz
+
+        if not (ring_matches and cation_matches):
+            results.append(False)
+            continue
+
+        found = False
+        for ring_match, cation_match in product(ring_matches, cation_matches):
+            ring_coords = ring_xyz[list(ring_match)]
+            centroid = Point3D(*get_centroid(ring_coords))
+            cation = Point3D(*cation_xyz[cation_match[0]])
+            dist = centroid.Distance(cation)
+            if dist <= interaction.distance:
+                normal = get_ring_normal_vector(centroid, ring_coords)
+                centroid_cation = centroid.DirectionVector(cation)
+                angle = normal.AngleTo(centroid_cation)
+                if angle_between_limits(angle, *interaction.angle, ring=True):
+                    found = True
+                    break
+        results.append(found)
+
+    return results
+
+
+def _has_pistacking_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+    """Check PiStacking interactions (FaceToFace, EdgeToFace, PiStacking)."""
+    results = []
+    for res in residues:
+        found = False
+        for pi_rings in product(interaction.pi_ring, repeat=2):
+            lig_matches = lig_res.GetSubstructMatches(pi_rings[1])
+            res_matches = res.GetSubstructMatches(pi_rings[0])
+
+            if not (lig_matches and res_matches):
+                continue
+
+            for lig_match, res_match in product(lig_matches, res_matches):
+                lig_pi_coords = lig_res.xyz[list(lig_match)]
+                lig_centroid = Point3D(*get_centroid(lig_pi_coords))
+                res_pi_coords = res.xyz[list(res_match)]
+                res_centroid = Point3D(*get_centroid(res_pi_coords))
+                centroid_dist = lig_centroid.Distance(res_centroid)
+
+                if centroid_dist > interaction.distance:
+                    continue
+
+                lig_normal = get_ring_normal_vector(lig_centroid, lig_pi_coords)
+                res_normal = get_ring_normal_vector(res_centroid, res_pi_coords)
+                plane_angle = lig_normal.AngleTo(res_normal)
+
+                if not angle_between_limits(plane_angle, *interaction.plane_angle, ring=True):
+                    continue
+
+                c1c2 = lig_centroid.DirectionVector(res_centroid)
+                c2c1 = res_centroid.DirectionVector(lig_centroid)
+                n1c1c2 = lig_normal.AngleTo(c1c2)
+                n2c2c1 = res_normal.AngleTo(c2c1)
+
+                ncc_ok = (
+                    angle_between_limits(n1c1c2, *interaction.normal_to_centroid_angle, ring=True) or
+                    angle_between_limits(n2c2c1, *interaction.normal_to_centroid_angle, ring=True)
+                )
+
+                if ncc_ok:
+                    if interaction.intersect:
+                        intersect = interaction._get_intersect_point(
+                            lig_normal, lig_centroid, res_normal, res_centroid
+                        )
+                        if intersect is not None:
+                            intersect_dist = min(
+                                lig_centroid.Distance(intersect),
+                                res_centroid.Distance(intersect)
+                            )
+                            if intersect_dist <= interaction.intersect_radius:
+                                found = True
+                                break
+                    else:
+                        found = True
+                        break
+            if found:
+                break
+        results.append(found)
+
+    return results
+
+
+def _has_pistacking_composite(interaction, lig_res, residues) -> list[bool]:
+    """Check PiStacking which is FaceToFace OR EdgeToFace."""
+    ftf_results = _has_pistacking_interaction(interaction.ftf, lig_res, residues, False)
+    etf_results = _has_pistacking_interaction(interaction.etf, lig_res, residues, False)
+    return [f or e for f, e in zip(ftf_results, etf_results)]
+
+
+def _has_vdwcontact_interaction(interaction, lig_res, residues) -> list[bool]:
+    """Check VdWContact interactions (all atoms, based on VdW radii)."""
+    lig_coords = lig_res.xyz
+    lig_elements = [lig_res.GetAtomWithIdx(i).GetSymbol() for i in range(lig_res.GetNumAtoms())]
+    lig_radii = jnp.array([interaction.vdwradii.get(e, 1.7) for e in lig_elements])
+
+    results = []
+    for res in residues:
+        res_coords = res.xyz
+        res_elements = [res.GetAtomWithIdx(i).GetSymbol() for i in range(res.GetNumAtoms())]
+        res_radii = jnp.array([interaction.vdwradii.get(e, 1.7) for e in res_elements])
+
+        distances = compute_distances_batch(lig_coords, res_coords)
+        radii_sum = lig_radii[:, None] + res_radii[None, :]
+        has_contact = bool((distances <= (radii_sum + interaction.tolerance)).any())
+        results.append(has_contact)
+
+    return results
+
+
+def has_interaction_batch(
+    interaction,
+    lig_res,
+    residues: list,
+) -> list[bool]:
+    """Check if interaction exists for each residue (boolean result).
+
+    Args:
+        interaction: A ProLIF interaction instance
+        lig_res: Ligand residue
+        residues: List of protein residues
+
+    Returns:
+        List of booleans, True if interaction exists for that residue.
+    """
+    is_inverted = _is_inverted_interaction(interaction)
+    itype = _get_interaction_type(interaction)
+
+    if itype == 'distance':
+        return _has_distance_interaction(interaction, lig_res, residues, is_inverted)
+    elif itype == 'singleangle':
+        return _has_singleangle_interaction(interaction, lig_res, residues, is_inverted)
+    elif itype == 'doubleangle':
+        return _has_doubleangle_interaction(interaction, lig_res, residues, is_inverted)
+    elif itype == 'cationpi':
+        return _has_cationpi_interaction(interaction, lig_res, residues, is_inverted)
+    elif itype == 'pistacking':
+        return _has_pistacking_interaction(interaction, lig_res, residues, is_inverted)
+    elif itype == 'pistacking_composite':
+        return _has_pistacking_composite(interaction, lig_res, residues)
+    elif itype == 'vdwcontact':
+        return _has_vdwcontact_interaction(interaction, lig_res, residues)
+    else:
+        return _has_distance_interaction(interaction, lig_res, residues, is_inverted)

--- a/prolif/interactions/_jax/integration.py
+++ b/prolif/interactions/_jax/integration.py
@@ -7,21 +7,22 @@ This module provides JAX-accelerated versions of ProLIF interactions that:
 
 """
 
+from collections.abc import Iterator
 from itertools import product
-from math import radians, degrees
-from typing import Iterator
+from typing import Any
 
 import jax.numpy as jnp
 from rdkit.Geometry import Point3D
 
-from prolif.interactions.base import Distance, SingleAngle, DoubleAngle, BasePiStacking
+from prolif.interactions.base import BasePiStacking, Distance, DoubleAngle, SingleAngle
 from prolif.utils import angle_between_limits, get_centroid, get_ring_normal_vector
-from .primitives import pairwise_distances, angle_at_vertex, angle_between_vectors
+
+from .primitives import pairwise_distances
 
 
 def compute_distances_batch(
-    lig_coords,
-    prot_coords,
+    lig_coords: Any,
+    prot_coords: Any,
 ) -> jnp.ndarray:
     """Compute pairwise distances between two atom sets using JAX.
 
@@ -44,7 +45,12 @@ class JAXDistanceMixin:
     while still using ProLIF's SMARTS matching.
     """
 
-    def detect(self, lig_res, prot_res) -> Iterator:
+    lig_pattern: Any
+    prot_pattern: Any
+    distance: float
+    metadata: Any
+
+    def detect(self, lig_res: Any, prot_res: Any) -> Iterator[Any]:
         """Detect interactions using JAX-accelerated distance calculation."""
         lig_matches = lig_res.GetSubstructMatches(self.lig_pattern)
         prot_matches = prot_res.GetSubstructMatches(self.prot_pattern)
@@ -75,10 +81,10 @@ class JAXDistanceMixin:
 
 
 def detect_distance_batch(
-    interaction,
-    lig_res,
-    residues: list,
-) -> list[list[dict]]:
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+) -> list[list[dict[str, Any]]]:
     """Batch detect Distance interactions across multiple residues.
 
     This is the main entry point for JAX-accelerated interaction detection.
@@ -135,41 +141,46 @@ def detect_distance_batch(
     return results
 
 
-def _is_inverted_interaction(interaction) -> bool:
+def _is_inverted_interaction(interaction: Any) -> bool:
     """Check if an interaction was created with invert_role."""
     name = type(interaction).__name__
-    return name in ('HBDonor', 'XBDonor', 'Anionic', 'PiCation', 'MetalAcceptor')
+    return name in {"HBDonor", "XBDonor", "Anionic", "PiCation", "MetalAcceptor"}
 
 
-def _get_interaction_type(interaction) -> str:
+def _get_interaction_type(interaction: Any) -> str:
     """Determine the base type of an interaction."""
     cls = type(interaction)
     name = cls.__name__
 
-    if name == 'VdWContact':
-        return 'vdwcontact'
-    if name == 'PiStacking':
-        return 'pistacking_composite'
-    if name in ('FaceToFace', 'EdgeToFace'):
-        return 'pistacking'
-    if name in ('CationPi', 'PiCation'):
-        return 'cationpi'
+    if name == "VdWContact":
+        return "vdwcontact"
+    if name == "PiStacking":
+        return "pistacking_composite"
+    if name in {"FaceToFace", "EdgeToFace"}:
+        return "pistacking"
+    if name in {"CationPi", "PiCation"}:
+        return "cationpi"
 
     if isinstance(interaction, BasePiStacking):
-        return 'pistacking'
-    if hasattr(interaction, 'pi_ring') and hasattr(interaction, 'cation'):
-        return 'cationpi'
+        return "pistacking"
+    if hasattr(interaction, "pi_ring") and hasattr(interaction, "cation"):
+        return "cationpi"
     if isinstance(interaction, DoubleAngle):
-        return 'doubleangle'
+        return "doubleangle"
     if isinstance(interaction, SingleAngle):
-        return 'singleangle'
+        return "singleangle"
     if isinstance(interaction, Distance):
-        return 'distance'
+        return "distance"
 
-    return 'distance'
+    return "distance"
 
 
-def _has_distance_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+def _has_distance_interaction(
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+    is_inverted: bool,
+) -> list[bool]:
     """Check Distance-based interactions."""
     if is_inverted:
         lig_pattern = interaction.prot_pattern
@@ -200,7 +211,12 @@ def _has_distance_interaction(interaction, lig_res, residues, is_inverted) -> li
     return results
 
 
-def _has_singleangle_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+def _has_singleangle_interaction(
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+    is_inverted: bool,
+) -> list[bool]:
     """Check SingleAngle-based interactions (HBAcceptor, HBDonor).
 
     For SingleAngle:
@@ -245,7 +261,12 @@ def _has_singleangle_interaction(interaction, lig_res, residues, is_inverted) ->
     return results
 
 
-def _has_doubleangle_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+def _has_doubleangle_interaction(
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+    is_inverted: bool,
+) -> list[bool]:
     """Check DoubleAngle-based interactions (XBAcceptor, XBDonor).
 
     For DoubleAngle:
@@ -293,7 +314,12 @@ def _has_doubleangle_interaction(interaction, lig_res, residues, is_inverted) ->
     return results
 
 
-def _has_cationpi_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+def _has_cationpi_interaction(
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+    is_inverted: bool,
+) -> list[bool]:
     """Check CationPi/PiCation interactions."""
     results = []
     for res in residues:
@@ -332,7 +358,12 @@ def _has_cationpi_interaction(interaction, lig_res, residues, is_inverted) -> li
     return results
 
 
-def _has_pistacking_interaction(interaction, lig_res, residues, is_inverted) -> list[bool]:
+def _has_pistacking_interaction(
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+    _is_inverted: bool,
+) -> list[bool]:
     """Check PiStacking interactions (FaceToFace, EdgeToFace, PiStacking)."""
     results = []
     for res in residues:
@@ -358,7 +389,9 @@ def _has_pistacking_interaction(interaction, lig_res, residues, is_inverted) -> 
                 res_normal = get_ring_normal_vector(res_centroid, res_pi_coords)
                 plane_angle = lig_normal.AngleTo(res_normal)
 
-                if not angle_between_limits(plane_angle, *interaction.plane_angle, ring=True):
+                if not angle_between_limits(
+                    plane_angle, *interaction.plane_angle, ring=True
+                ):
                     continue
 
                 c1c2 = lig_centroid.DirectionVector(res_centroid)
@@ -366,9 +399,10 @@ def _has_pistacking_interaction(interaction, lig_res, residues, is_inverted) -> 
                 n1c1c2 = lig_normal.AngleTo(c1c2)
                 n2c2c1 = res_normal.AngleTo(c2c1)
 
-                ncc_ok = (
-                    angle_between_limits(n1c1c2, *interaction.normal_to_centroid_angle, ring=True) or
-                    angle_between_limits(n2c2c1, *interaction.normal_to_centroid_angle, ring=True)
+                ncc_ok = angle_between_limits(
+                    n1c1c2, *interaction.normal_to_centroid_angle, ring=True
+                ) or angle_between_limits(
+                    n2c2c1, *interaction.normal_to_centroid_angle, ring=True
                 )
 
                 if ncc_ok:
@@ -379,7 +413,7 @@ def _has_pistacking_interaction(interaction, lig_res, residues, is_inverted) -> 
                         if intersect is not None:
                             intersect_dist = min(
                                 lig_centroid.Distance(intersect),
-                                res_centroid.Distance(intersect)
+                                res_centroid.Distance(intersect),
                             )
                             if intersect_dist <= interaction.intersect_radius:
                                 found = True
@@ -394,23 +428,35 @@ def _has_pistacking_interaction(interaction, lig_res, residues, is_inverted) -> 
     return results
 
 
-def _has_pistacking_composite(interaction, lig_res, residues) -> list[bool]:
+def _has_pistacking_composite(
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+) -> list[bool]:
     """Check PiStacking which is FaceToFace OR EdgeToFace."""
     ftf_results = _has_pistacking_interaction(interaction.ftf, lig_res, residues, False)
     etf_results = _has_pistacking_interaction(interaction.etf, lig_res, residues, False)
-    return [f or e for f, e in zip(ftf_results, etf_results)]
+    return [f or e for f, e in zip(ftf_results, etf_results, strict=False)]
 
 
-def _has_vdwcontact_interaction(interaction, lig_res, residues) -> list[bool]:
+def _has_vdwcontact_interaction(
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
+) -> list[bool]:
     """Check VdWContact interactions (all atoms, based on VdW radii)."""
     lig_coords = lig_res.xyz
-    lig_elements = [lig_res.GetAtomWithIdx(i).GetSymbol() for i in range(lig_res.GetNumAtoms())]
+    lig_elements = [
+        lig_res.GetAtomWithIdx(i).GetSymbol() for i in range(lig_res.GetNumAtoms())
+    ]
     lig_radii = jnp.array([interaction.vdwradii.get(e, 1.7) for e in lig_elements])
 
     results = []
     for res in residues:
         res_coords = res.xyz
-        res_elements = [res.GetAtomWithIdx(i).GetSymbol() for i in range(res.GetNumAtoms())]
+        res_elements = [
+            res.GetAtomWithIdx(i).GetSymbol() for i in range(res.GetNumAtoms())
+        ]
         res_radii = jnp.array([interaction.vdwradii.get(e, 1.7) for e in res_elements])
 
         distances = compute_distances_batch(lig_coords, res_coords)
@@ -422,9 +468,9 @@ def _has_vdwcontact_interaction(interaction, lig_res, residues) -> list[bool]:
 
 
 def has_interaction_batch(
-    interaction,
-    lig_res,
-    residues: list,
+    interaction: Any,
+    lig_res: Any,
+    residues: list[Any],
 ) -> list[bool]:
     """Check if interaction exists for each residue (boolean result).
 
@@ -439,19 +485,18 @@ def has_interaction_batch(
     is_inverted = _is_inverted_interaction(interaction)
     itype = _get_interaction_type(interaction)
 
-    if itype == 'distance':
+    if itype == "distance":
         return _has_distance_interaction(interaction, lig_res, residues, is_inverted)
-    elif itype == 'singleangle':
+    if itype == "singleangle":
         return _has_singleangle_interaction(interaction, lig_res, residues, is_inverted)
-    elif itype == 'doubleangle':
+    if itype == "doubleangle":
         return _has_doubleangle_interaction(interaction, lig_res, residues, is_inverted)
-    elif itype == 'cationpi':
+    if itype == "cationpi":
         return _has_cationpi_interaction(interaction, lig_res, residues, is_inverted)
-    elif itype == 'pistacking':
+    if itype == "pistacking":
         return _has_pistacking_interaction(interaction, lig_res, residues, is_inverted)
-    elif itype == 'pistacking_composite':
+    if itype == "pistacking_composite":
         return _has_pistacking_composite(interaction, lig_res, residues)
-    elif itype == 'vdwcontact':
+    if itype == "vdwcontact":
         return _has_vdwcontact_interaction(interaction, lig_res, residues)
-    else:
-        return _has_distance_interaction(interaction, lig_res, residues, is_inverted)
+    return _has_distance_interaction(interaction, lig_res, residues, is_inverted)

--- a/prolif/interactions/_jax/primitives.py
+++ b/prolif/interactions/_jax/primitives.py
@@ -1,10 +1,4 @@
-"""
-JAX-accelerated geometric primitives for molecular interaction calculations.
-
-These functions provide GPU-compatible, vectorized implementations of
-geometric operations used in interaction fingerprinting. All functions
-are designed to work with batched inputs and can be JIT-compiled.
-"""
+"""Geometric primitives used by JAX interaction calculations."""
 
 from typing import cast
 
@@ -31,8 +25,6 @@ def batch_centroids(
     coords: jnp.ndarray, group_indices: list[jnp.ndarray]
 ) -> jnp.ndarray:
     """Compute centroids for multiple groups of atoms.
-
-    Uses segment_sum for efficient computation over variable-size groups.
 
     Args:
         coords: (N, 3) array of all atom coordinates.
@@ -80,9 +72,7 @@ def batch_ring_normals_masked(
     index_padded: jnp.ndarray,
     mask: jnp.ndarray,
 ) -> jnp.ndarray:
-    """Compute unit normals for rings using the same method as ProLIF's
-    ``get_ring_normal_vector``: cross product of unit vectors from the centroid
-    to the first two ring atoms.
+    """Compute unit normal vectors for multiple rings.
 
     Args:
         coords: (N, 3) array of all atom coordinates.
@@ -107,9 +97,7 @@ def batch_ring_normals_masked(
 
 
 def ring_normal(coords: jnp.ndarray, ring_indices: jnp.ndarray) -> jnp.ndarray:
-    """Compute unit normal vector to a ring plane using the same method as
-    ProLIF's ``get_ring_normal_vector``: cross product of unit vectors from the
-    centroid to the first two ring atoms.
+    """Compute the unit normal vector of one ring.
 
     Args:
         coords: (N, 3) array of all atom coordinates.
@@ -135,15 +123,13 @@ def ring_normal(coords: jnp.ndarray, ring_indices: jnp.ndarray) -> jnp.ndarray:
 def batch_ring_normals(
     coords: jnp.ndarray, ring_indices_list: list[jnp.ndarray]
 ) -> jnp.ndarray:
-    """Compute unit normal vectors for multiple rings using Newell's method."""
+    """Compute unit normal vectors for multiple rings."""
     normals = [ring_normal(coords, idxs) for idxs in ring_indices_list]
     return jnp.stack(normals, axis=0)
 
 
 def angle_between_vectors(v1: jnp.ndarray, v2: jnp.ndarray) -> jnp.ndarray:
     """Compute angle between vectors.
-
-    Handles arbitrary batch dimensions via axis=-1 operations.
 
     Args:
         v1: (..., 3) array of vectors.
@@ -164,9 +150,6 @@ def angle_at_vertex(
 ) -> jnp.ndarray:
     """Compute angle formed at a vertex point.
 
-    Calculates the angle p1-vertex-p2, useful for angles like D-H-A
-    in hydrogen bonds.
-
     Args:
         p1: (..., 3) first point.
         vertex: (..., 3) vertex point where angle is measured.
@@ -184,8 +167,6 @@ def point_to_plane_distance(
     points: jnp.ndarray, plane_point: jnp.ndarray, plane_normal: jnp.ndarray
 ) -> jnp.ndarray:
     """Compute signed distances from points to a plane.
-
-    Useful for cation-pi and pi-stacking geometric checks.
 
     Args:
         points: (N, 3) array of points.

--- a/prolif/interactions/_jax/primitives.py
+++ b/prolif/interactions/_jax/primitives.py
@@ -1,0 +1,194 @@
+"""
+JAX-accelerated geometric primitives for molecular interaction calculations.
+
+These functions provide GPU-compatible, vectorized implementations of
+geometric operations used in interaction fingerprinting. All functions
+are designed to work with batched inputs and can be JIT-compiled.
+"""
+
+import jax.numpy as jnp
+from jax.ops import segment_sum
+
+
+def pairwise_distances(coords1: jnp.ndarray, coords2: jnp.ndarray) -> jnp.ndarray:
+    """Compute pairwise Euclidean distances between two sets of points.
+
+    Args:
+        coords1: (N, 3) array of 3D points.
+        coords2: (M, 3) array of 3D points.
+
+    Returns:
+        (N, M) distance matrix where entry [i,j] is the distance
+        between coords1[i] and coords2[j].
+    """
+    diff = coords1[:, None, :] - coords2[None, :, :]
+    return jnp.linalg.norm(diff, axis=-1)
+
+
+def batch_centroids(
+    coords: jnp.ndarray, group_indices: list[jnp.ndarray]
+) -> jnp.ndarray:
+    """Compute centroids for multiple groups of atoms.
+
+    Uses segment_sum for efficient computation over variable-size groups.
+
+    Args:
+        coords: (N, 3) array of all atom coordinates.
+        group_indices: List of K arrays, each containing atom indices for one group.
+
+    Returns:
+        (K, 3) array of centroid positions.
+    """
+    K = len(group_indices)
+    flat_indices = jnp.concatenate(group_indices)
+    segment_ids = jnp.repeat(
+        jnp.arange(K), jnp.array([len(g) for g in group_indices])
+    )
+
+    points = coords[flat_indices]
+    sums = segment_sum(points, segment_ids, num_segments=K)
+    counts = segment_sum(jnp.ones(len(flat_indices)), segment_ids, num_segments=K)
+
+    return sums / counts[:, None]
+
+
+def batch_centroids_masked(
+    coords: jnp.ndarray,
+    index_padded: jnp.ndarray,
+    mask: jnp.ndarray,
+) -> jnp.ndarray:
+    """Compute centroids for groups using padded indices and masks.
+
+    Args:
+        coords: (N, 3) array of all atom coordinates.
+        index_padded: (K, S) int array of atom indices per group.
+        mask: (K, S) bool array where True marks a valid atom in the group.
+
+    Returns:
+        (K, 3) array of centroid positions.
+    """
+    gathered = coords[index_padded]
+    weights = mask[..., None]
+    weighted = gathered * weights
+    sums = jnp.sum(weighted, axis=1)
+    counts = jnp.sum(mask, axis=1, keepdims=True)
+    return sums / counts
+
+
+def batch_ring_normals_masked(
+    coords: jnp.ndarray,
+    index_padded: jnp.ndarray,
+    mask: jnp.ndarray,
+) -> jnp.ndarray:
+    """Compute unit normals for rings using the same method as ProLIF's
+    ``get_ring_normal_vector``: cross product of unit vectors from the centroid
+    to the first two ring atoms.
+
+    Args:
+        coords: (N, 3) array of all atom coordinates.
+        index_padded: (K, S) int array of atom indices per ring.
+        mask: (K, S) bool array where True marks a valid atom in the ring.
+
+    Returns:
+        (K, 3) array of unit normal vectors.
+    """
+    pts = coords[index_padded]
+    centroid = (pts * mask[..., None]).sum(axis=1) / mask.sum(axis=1, keepdims=True)
+    a = pts[:, 0, :] - centroid
+    b = pts[:, 1, :] - centroid
+    a_hat = a / jnp.clip(jnp.linalg.norm(a, axis=-1, keepdims=True), 1e-8)
+    b_hat = b / jnp.clip(jnp.linalg.norm(b, axis=-1, keepdims=True), 1e-8)
+    normals = jnp.cross(a_hat, b_hat)
+    norms = jnp.linalg.norm(normals, axis=1, keepdims=True)
+    normals = jnp.where(norms > 0, normals / norms, jnp.array([0.0, 0.0, 1.0])[None, :])
+    return normals
+
+
+def ring_normal(coords: jnp.ndarray, ring_indices: jnp.ndarray) -> jnp.ndarray:
+    """Compute unit normal vector to a ring plane using the same method as
+    ProLIF's ``get_ring_normal_vector``: cross product of unit vectors from the
+    centroid to the first two ring atoms.
+
+    Args:
+        coords: (N, 3) array of all atom coordinates.
+        ring_indices: (R,) array of atom indices forming the ring (R >= 3).
+
+    Returns:
+        (3,) unit normal vector perpendicular to the ring plane.
+    """
+    pts = coords[ring_indices]
+    centroid = pts.mean(axis=0)
+    a = pts[0] - centroid
+    b = pts[1] - centroid
+    a_hat = a / jnp.clip(jnp.linalg.norm(a), 1e-8)
+    b_hat = b / jnp.clip(jnp.linalg.norm(b), 1e-8)
+    normal = jnp.cross(a_hat, b_hat)
+    norm = jnp.linalg.norm(normal)
+    return jnp.where(norm > 0, normal / norm, jnp.array([0.0, 0.0, 1.0]))
+
+
+def batch_ring_normals(
+    coords: jnp.ndarray, ring_indices_list: list[jnp.ndarray]
+) -> jnp.ndarray:
+    """Compute unit normal vectors for multiple rings using Newell's method."""
+    normals = [ring_normal(coords, idxs) for idxs in ring_indices_list]
+    return jnp.stack(normals, axis=0)
+
+
+def angle_between_vectors(v1: jnp.ndarray, v2: jnp.ndarray) -> jnp.ndarray:
+    """Compute angle between vectors.
+
+    Handles arbitrary batch dimensions via axis=-1 operations.
+
+    Args:
+        v1: (..., 3) array of vectors.
+        v2: (..., 3) array of vectors with same batch shape as v1.
+
+    Returns:
+        (...,) array of angles in radians, range [0, pi].
+    """
+    dot = jnp.sum(v1 * v2, axis=-1)
+    norm1 = jnp.linalg.norm(v1, axis=-1)
+    norm2 = jnp.linalg.norm(v2, axis=-1)
+    cos_angle = dot / (norm1 * norm2)
+    return jnp.arccos(jnp.clip(cos_angle, -1, 1))
+
+
+def angle_at_vertex(
+    p1: jnp.ndarray, vertex: jnp.ndarray, p2: jnp.ndarray
+) -> jnp.ndarray:
+    """Compute angle formed at a vertex point.
+
+    Calculates the angle p1-vertex-p2, useful for angles like D-H-A
+    in hydrogen bonds.
+
+    Args:
+        p1: (..., 3) first point.
+        vertex: (..., 3) vertex point where angle is measured.
+        p2: (..., 3) second point.
+
+    Returns:
+        (...,) angles in radians.
+    """
+    v1 = p1 - vertex
+    v2 = p2 - vertex
+    return angle_between_vectors(v1, v2)
+
+
+def point_to_plane_distance(
+    points: jnp.ndarray, plane_point: jnp.ndarray, plane_normal: jnp.ndarray
+) -> jnp.ndarray:
+    """Compute signed distances from points to a plane.
+
+    Useful for cation-pi and pi-stacking geometric checks.
+
+    Args:
+        points: (N, 3) array of points.
+        plane_point: (3,) a point on the plane (e.g., ring centroid).
+        plane_normal: (3,) unit normal vector to the plane.
+
+    Returns:
+        (N,) signed distances. Positive values indicate the point is on
+        the same side as the normal vector.
+    """
+    return jnp.dot(points - plane_point, plane_normal)

--- a/prolif/interactions/_jax/primitives.py
+++ b/prolif/interactions/_jax/primitives.py
@@ -6,6 +6,8 @@ geometric operations used in interaction fingerprinting. All functions
 are designed to work with batched inputs and can be JIT-compiled.
 """
 
+from typing import cast
+
 import jax.numpy as jnp
 from jax.ops import segment_sum
 
@@ -22,7 +24,7 @@ def pairwise_distances(coords1: jnp.ndarray, coords2: jnp.ndarray) -> jnp.ndarra
         between coords1[i] and coords2[j].
     """
     diff = coords1[:, None, :] - coords2[None, :, :]
-    return jnp.linalg.norm(diff, axis=-1)
+    return cast(jnp.ndarray, jnp.linalg.norm(diff, axis=-1))
 
 
 def batch_centroids(
@@ -41,9 +43,7 @@ def batch_centroids(
     """
     K = len(group_indices)
     flat_indices = jnp.concatenate(group_indices)
-    segment_ids = jnp.repeat(
-        jnp.arange(K), jnp.array([len(g) for g in group_indices])
-    )
+    segment_ids = jnp.repeat(jnp.arange(K), jnp.array([len(g) for g in group_indices]))
 
     points = coords[flat_indices]
     sums = segment_sum(points, segment_ids, num_segments=K)
@@ -100,8 +100,10 @@ def batch_ring_normals_masked(
     b_hat = b / jnp.clip(jnp.linalg.norm(b, axis=-1, keepdims=True), 1e-8)
     normals = jnp.cross(a_hat, b_hat)
     norms = jnp.linalg.norm(normals, axis=1, keepdims=True)
-    normals = jnp.where(norms > 0, normals / norms, jnp.array([0.0, 0.0, 1.0])[None, :])
-    return normals
+    return cast(
+        jnp.ndarray,
+        jnp.where(norms > 0, normals / norms, jnp.array([0.0, 0.0, 1.0])[None, :]),
+    )
 
 
 def ring_normal(coords: jnp.ndarray, ring_indices: jnp.ndarray) -> jnp.ndarray:
@@ -124,7 +126,10 @@ def ring_normal(coords: jnp.ndarray, ring_indices: jnp.ndarray) -> jnp.ndarray:
     b_hat = b / jnp.clip(jnp.linalg.norm(b), 1e-8)
     normal = jnp.cross(a_hat, b_hat)
     norm = jnp.linalg.norm(normal)
-    return jnp.where(norm > 0, normal / norm, jnp.array([0.0, 0.0, 1.0]))
+    return cast(
+        jnp.ndarray,
+        jnp.where(norm > 0, normal / norm, jnp.array([0.0, 0.0, 1.0])),
+    )
 
 
 def batch_ring_normals(

--- a/prolif/interactions/base.py
+++ b/prolif/interactions/base.py
@@ -142,7 +142,7 @@ class Interaction(ABC):
         """
         return min(
             self(lig_res, prot_res, metadata=True),
-            key=itemgetter("distance"),  # type: ignore[arg-type]
+            key=itemgetter("distance"),
             default=None,
         )
 

--- a/prolif/interactions/base.py
+++ b/prolif/interactions/base.py
@@ -10,7 +10,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
 from itertools import product
 from math import degrees, radians
-from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
 
 import numpy as np
@@ -142,7 +141,9 @@ class Interaction(ABC):
         """
         return min(
             self(lig_res, prot_res, metadata=True),
-            key=itemgetter("distance"),
+            key=lambda metadata: (
+                metadata["distance"] if metadata is not None else float("inf")
+            ),
             default=None,
         )
 

--- a/prolif/interactions/utils.py
+++ b/prolif/interactions/utils.py
@@ -32,7 +32,7 @@ def get_mapindex(res: "Residue", index: int) -> int:
     mapindex : int
         The index of the atom in the :class:`~prolif.molecule.Molecule`
     """
-    return res.GetAtomWithIdx(index).GetUnsignedProp("mapindex")
+    return int(res.GetAtomWithIdx(index).GetUnsignedProp("mapindex"))
 
 
 def _distance_3args_l1_p1(

--- a/prolif/plotting/barcode.py
+++ b/prolif/plotting/barcode.py
@@ -172,19 +172,19 @@ class Barcode:
         residues = self.df.index.get_level_values("protein")
         interactions = self.df.index.get_level_values("interaction")
         if residues_tick_location == "top":
-            indices = [
+            residue_indices = [
                 i
                 for i in range(n_items)
                 if (i - 1 >= 0 and residues[i - 1] != residues[i]) or i == 0
             ]
         else:
-            indices = [
+            residue_indices = [
                 i
                 for i in range(n_items)
                 if (i + 1 < n_items and residues[i + 1] != residues[i])
                 or i + 1 == n_items
             ]
-        ax.yaxis.set_ticks(indices, residues[indices])
+        ax.yaxis.set_ticks(residue_indices, residues[residue_indices])
 
         # legend
         values: list[int] = np.unique(self.df.values).tolist()

--- a/prolif/plotting/network/lignetwork.py
+++ b/prolif/plotting/network/lignetwork.py
@@ -415,13 +415,14 @@ class LigNetwork:
             ),
         )
         # threshold and keep most occuring ligand atom
-        return (
+        return cast(
+            pd.DataFrame,
             df[df["weight_total"] >= threshold]
             .drop(columns="weight_total")
             .sort_values("weight", ascending=False)
             .groupby(level=["ligand", "protein", "interaction"])
             .head(1)
-            .sort_index()
+            .sort_index(),
         )
 
     @classmethod
@@ -432,8 +433,11 @@ class LigNetwork:
         data = cls._get_records(ifp, all_metadata=display_all)
         df = pd.DataFrame(data)
         df["weight"] = 1
-        return df.set_index(["ligand", "protein", "interaction", "atoms"]).reindex(
-            columns=["weight", "distance", "components"],
+        return cast(
+            pd.DataFrame,
+            df.set_index(["ligand", "protein", "interaction", "atoms"]).reindex(
+                columns=["weight", "distance", "components"],
+            ),
         )
 
     def _make_carbon(self) -> dict[str, Any]:
@@ -571,12 +575,21 @@ class LigNetwork:
             resname = ResidueId.from_string(prot_res).name
             restype = self.RESIDUE_TYPES.get(resname)
             restypes[prot_res] = restype
-            color = self.COLORS["residues"].get(restype, self._default_residue_color)
+            color = (
+                self.COLORS["residues"].get(restype, self._default_residue_color)
+                if restype is not None
+                else self._default_residue_color
+            )
+            font_color = (
+                self._FONTCOLORS.get(restype, "black")
+                if restype is not None
+                else "black"
+            )
             node = {
                 "id": prot_res,
                 "label": prot_res,
                 "color": color,
-                "font": {"color": self._FONTCOLORS.get(restype, "black")},
+                "font": {"color": font_color},
                 "shape": "box",
                 "borderWidth": 0,
                 "physics": True,
@@ -595,6 +608,7 @@ class LigNetwork:
             ],
             self.df.iterrows(),
         ):
+            origin: str | int
             if components.startswith("ligand"):
                 if interaction in self._LIG_PI_INTERACTIONS:
                     centroid = self._get_ring_centroid(lig_indices)
@@ -621,7 +635,7 @@ class LigNetwork:
                 "weight": weight,
                 "weight_pct": weight * 100,
             }
-            edge = {
+            edge: dict[str, Any] = {
                 "from": origin,
                 "to": prot_res,
                 "title": self._edge_title_formatter.format_map(int_data),

--- a/prolif/plotting/network/lignetwork.py
+++ b/prolif/plotting/network/lignetwork.py
@@ -415,14 +415,13 @@ class LigNetwork:
             ),
         )
         # threshold and keep most occuring ligand atom
-        return cast(
-            pd.DataFrame,
+        return (
             df[df["weight_total"] >= threshold]
             .drop(columns="weight_total")
             .sort_values("weight", ascending=False)
             .groupby(level=["ligand", "protein", "interaction"])
             .head(1)
-            .sort_index(),
+            .sort_index()
         )
 
     @classmethod
@@ -433,11 +432,8 @@ class LigNetwork:
         data = cls._get_records(ifp, all_metadata=display_all)
         df = pd.DataFrame(data)
         df["weight"] = 1
-        return cast(
-            pd.DataFrame,
-            df.set_index(["ligand", "protein", "interaction", "atoms"]).reindex(
-                columns=["weight", "distance", "components"],
-            ),
+        return df.set_index(["ligand", "protein", "interaction", "atoms"]).reindex(
+            columns=["weight", "distance", "components"],
         )
 
     def _make_carbon(self) -> dict[str, Any]:

--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from functools import wraps
 from importlib.util import find_spec
 from math import pi
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -337,7 +337,7 @@ def to_dataframe(
     if drop_empty:
         mask = (df != empty_value).any(axis=0)
         df = df.loc[:, mask]
-    return df
+    return cast(pd.DataFrame, df)
 
 
 def pandas_series_to_bv(s: pd.Series) -> ExplicitBitVect:

--- a/prolif/utils.py
+++ b/prolif/utils.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from functools import wraps
 from importlib.util import find_spec
 from math import pi
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
 import numpy as np
 import pandas as pd
@@ -337,7 +337,7 @@ def to_dataframe(
     if drop_empty:
         mask = (df != empty_value).any(axis=0)
         df = df.loc[:, mask]
-    return cast(pd.DataFrame, df)
+    return df
 
 
 def pandas_series_to_bv(s: pd.Series) -> ExplicitBitVect:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/*" = ["ARG001"]
+"benchmarks/*" = ["E501", "F841", "FURB113", "RUF059", "SIM105", "SIM108", "SIM113", "T201"]
 
 [tool.isort]
 profile = "black"

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -7,17 +7,17 @@ All tests are skipped if JAX is not installed. The key test is
 on the standard ProLIF test trajectory for all 9 interaction types.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 
 import prolif
-from prolif.datafiles import TOP, TRAJ
 
 jax = pytest.importorskip("jax", reason="JAX not installed")
 
 from prolif.interactions._jax import JAX_AVAILABLE, analyze_trajectory  # noqa: E402
+from prolif.interactions._jax.api import InteractionResult  # noqa: E402
 
 if TYPE_CHECKING:
     from MDAnalysis.core.universe import Universe
@@ -44,7 +44,7 @@ INTERACTIONS = [
 
 
 @pytest.fixture(scope="module")
-def jax_result(u: "Universe"):
+def jax_result(u: "Universe") -> InteractionResult:
     """Run analyze_trajectory on the standard test trajectory."""
     return analyze_trajectory(
         u,
@@ -54,10 +54,8 @@ def jax_result(u: "Universe"):
 
 
 @pytest.fixture(scope="module")
-def prolif_fp(u: "Universe"):
-    """Run Fingerprint.run on the standard test trajectory.
-
-    """
+def prolif_fp(u: "Universe") -> prolif.Fingerprint:
+    """Run Fingerprint.run on the standard test trajectory."""
     fp = prolif.Fingerprint(
         [
             "Hydrophobic",
@@ -71,8 +69,13 @@ def prolif_fp(u: "Universe"):
             "PiCation",
         ]
     )
-    fp.run(u.trajectory, u.select_atoms("resname LIG"), u.select_atoms("protein"),
-           progress=False, n_jobs=1)
+    fp.run(
+        u.trajectory,
+        u.select_atoms("resname LIG"),
+        u.select_atoms("protein"),
+        progress=False,
+        n_jobs=1,
+    )
     return fp
 
 
@@ -81,13 +84,15 @@ def prolif_fp(u: "Universe"):
 # ---------------------------------------------------------------------------
 
 
-def test_jax_available():
+def test_jax_available() -> None:
     assert JAX_AVAILABLE
 
 
-def test_import():
-    from prolif.interactions._jax import analyze_trajectory  # noqa: F401
-    from prolif.interactions._jax import has_interactions_frames  # noqa: F401
+def test_import() -> None:
+    from prolif.interactions._jax import (
+        analyze_trajectory,  # noqa: F401
+        has_interactions_frames,  # noqa: F401
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +100,7 @@ def test_import():
 # ---------------------------------------------------------------------------
 
 
-def test_result_shape(jax_result, u: "Universe"):
+def test_result_shape(jax_result: InteractionResult, u: "Universe") -> None:
     F = len(u.trajectory)
     R = jax_result.n_residues
     assert jax_result.n_frames == F
@@ -106,16 +111,16 @@ def test_result_shape(jax_result, u: "Universe"):
         assert arr.dtype == bool, f"{name}: expected bool dtype"
 
 
-def test_result_has_all_interactions(jax_result):
+def test_result_has_all_interactions(jax_result: InteractionResult) -> None:
     for name in INTERACTIONS:
         assert name in jax_result.interactions, f"Missing interaction: {name}"
 
 
-def test_result_has_residue_ids(jax_result):
+def test_result_has_residue_ids(jax_result: InteractionResult) -> None:
     assert len(jax_result.residue_ids) == jax_result.n_residues
 
 
-def test_to_dataframe(jax_result, u: "Universe"):
+def test_to_dataframe(jax_result: InteractionResult, u: "Universe") -> None:
     df = jax_result.to_dataframe()
     assert len(df) == len(u.trajectory)
     assert df.columns.names == ["residue", "interaction"]
@@ -126,7 +131,11 @@ def test_to_dataframe(jax_result, u: "Universe"):
 # ---------------------------------------------------------------------------
 
 
-def _prolif_interaction_array(prolif_fp, interaction_name, residue_ids):
+def _prolif_interaction_array(
+    prolif_fp: prolif.Fingerprint,
+    interaction_name: str,
+    residue_ids: list[Any],
+) -> np.ndarray:
     """Extract (F, R) bool array from ProLIF Fingerprint matching jax residue_ids.
 
     ProLIF ifp keys are (lig_id, res_id) tuples; we match on the protein res_id.
@@ -146,7 +155,11 @@ def _prolif_interaction_array(prolif_fp, interaction_name, residue_ids):
 
 
 @pytest.mark.parametrize("interaction_name", INTERACTIONS)
-def test_analyze_trajectory_matches_prolif(jax_result, prolif_fp, interaction_name):
+def test_analyze_trajectory_matches_prolif(
+    jax_result: InteractionResult,
+    prolif_fp: prolif.Fingerprint,
+    interaction_name: str,
+) -> None:
     """JAX and ProLIF must agree on every (frame, residue) pair."""
     jax_arr = jax_result.interactions[interaction_name]  # (F, R)
 
@@ -158,7 +171,7 @@ def test_analyze_trajectory_matches_prolif(jax_result, prolif_fp, interaction_na
     matches = int((jax_arr == prolif_arr).sum())
     accuracy = matches / total * 100
 
-    assert accuracy == 100.0, (
+    assert matches == total, (
         f"{interaction_name}: {accuracy:.1f}% accuracy "
         f"({total - matches} mismatches out of {total})"
     )
@@ -169,7 +182,7 @@ def test_analyze_trajectory_matches_prolif(jax_result, prolif_fp, interaction_na
 # ---------------------------------------------------------------------------
 
 
-def test_residue_mode_all_ge_first(u: "Universe"):
+def test_residue_mode_all_ge_first(u: "Universe") -> None:
     result_first = analyze_trajectory(
         u,
         ligand_selection="resname LIG",
@@ -190,7 +203,7 @@ def test_residue_mode_all_ge_first(u: "Universe"):
 # ---------------------------------------------------------------------------
 
 
-def test_pairwise_distances():
+def test_pairwise_distances() -> None:
     import jax.numpy as jnp
 
     from prolif.interactions._jax.primitives import pairwise_distances
@@ -205,18 +218,20 @@ def test_pairwise_distances():
     np.testing.assert_allclose(d[1, 1], 3.0, atol=1e-5)
 
 
-def test_ring_normal_perpendicular():
+def test_ring_normal_perpendicular() -> None:
     import jax.numpy as jnp
 
     from prolif.interactions._jax.primitives import ring_normal
 
     # Simple square ring in the XY plane — normal should be along Z
-    coords = jnp.array([
-        [1.0, 0.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [-1.0, 0.0, 0.0],
-        [0.0, -1.0, 0.0],
-    ])
+    coords = jnp.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+        ]
+    )
     indices = jnp.array([0, 1, 2, 3])
     n = ring_normal(coords, indices)
     assert n.shape == (3,)
@@ -224,7 +239,7 @@ def test_ring_normal_perpendicular():
     np.testing.assert_allclose(abs(float(n[2])), 1.0, atol=1e-5)
 
 
-def test_angle_between_vectors():
+def test_angle_between_vectors() -> None:
     import jax.numpy as jnp
 
     from prolif.interactions._jax.primitives import angle_between_vectors

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -1,0 +1,239 @@
+"""
+Tests for the JAX-accelerated interaction fingerprinting module.
+
+All tests are skipped if JAX is not installed. The key test is
+``test_analyze_trajectory_matches_prolif``, which checks that
+``analyze_trajectory()`` produces results matching ``Fingerprint.run()``
+on the standard ProLIF test trajectory for all 9 interaction types.
+"""
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+import prolif
+from prolif.datafiles import TOP, TRAJ
+
+jax = pytest.importorskip("jax", reason="JAX not installed")
+
+from prolif.interactions._jax import JAX_AVAILABLE, analyze_trajectory  # noqa: E402
+
+if TYPE_CHECKING:
+    from MDAnalysis.core.universe import Universe
+
+
+pytestmark = pytest.mark.skipif(not JAX_AVAILABLE, reason="JAX not available")
+
+INTERACTIONS = [
+    "Hydrophobic",
+    "Cationic",
+    "Anionic",
+    "VdWContact",
+    "HBAcceptor",
+    "HBDonor",
+    "PiStacking",
+    "CationPi",
+    "PiCation",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def jax_result(u: "Universe"):
+    """Run analyze_trajectory on the standard test trajectory."""
+    return analyze_trajectory(
+        u,
+        ligand_selection="resname LIG",
+        protein_selection="protein",
+    )
+
+
+@pytest.fixture(scope="module")
+def prolif_fp(u: "Universe"):
+    """Run Fingerprint.run on the standard test trajectory.
+
+    """
+    fp = prolif.Fingerprint(
+        [
+            "Hydrophobic",
+            "Cationic",
+            "Anionic",
+            "VdWContact",
+            "HBAcceptor",
+            "HBDonor",
+            "PiStacking",
+            "CationPi",
+            "PiCation",
+        ]
+    )
+    fp.run(u.trajectory, u.select_atoms("resname LIG"), u.select_atoms("protein"),
+           progress=False, n_jobs=1)
+    return fp
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_jax_available():
+    assert JAX_AVAILABLE
+
+
+def test_import():
+    from prolif.interactions._jax import analyze_trajectory  # noqa: F401
+    from prolif.interactions._jax import has_interactions_frames  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Output shape and types
+# ---------------------------------------------------------------------------
+
+
+def test_result_shape(jax_result, u: "Universe"):
+    F = len(u.trajectory)
+    R = jax_result.n_residues
+    assert jax_result.n_frames == F
+    assert R > 0
+    for name in INTERACTIONS:
+        arr = jax_result.interactions[name]
+        assert arr.shape == (F, R), f"{name}: expected ({F}, {R}), got {arr.shape}"
+        assert arr.dtype == bool, f"{name}: expected bool dtype"
+
+
+def test_result_has_all_interactions(jax_result):
+    for name in INTERACTIONS:
+        assert name in jax_result.interactions, f"Missing interaction: {name}"
+
+
+def test_result_has_residue_ids(jax_result):
+    assert len(jax_result.residue_ids) == jax_result.n_residues
+
+
+def test_to_dataframe(jax_result, u: "Universe"):
+    df = jax_result.to_dataframe()
+    assert len(df) == len(u.trajectory)
+    assert df.columns.names == ["residue", "interaction"]
+
+
+# ---------------------------------------------------------------------------
+# Accuracy: JAX must match ProLIF on all interactions
+# ---------------------------------------------------------------------------
+
+
+def _prolif_interaction_array(prolif_fp, interaction_name, residue_ids):
+    """Extract (F, R) bool array from ProLIF Fingerprint matching jax residue_ids.
+
+    ProLIF ifp keys are (lig_id, res_id) tuples; we match on the protein res_id.
+    """
+    F = len(prolif_fp.ifp)
+    R = len(residue_ids)
+    result = np.zeros((F, R), dtype=bool)
+    rid_to_idx = {rid: i for i, rid in enumerate(residue_ids)}
+
+    for f_i in range(F):
+        for (_, res_id), interactions in prolif_fp.ifp[f_i].items():
+            r_i = rid_to_idx.get(res_id)
+            if r_i is not None and interaction_name in interactions:
+                result[f_i, r_i] = True
+
+    return result
+
+
+@pytest.mark.parametrize("interaction_name", INTERACTIONS)
+def test_analyze_trajectory_matches_prolif(jax_result, prolif_fp, interaction_name):
+    """JAX and ProLIF must agree on every (frame, residue) pair."""
+    jax_arr = jax_result.interactions[interaction_name]  # (F, R)
+
+    prolif_arr = _prolif_interaction_array(
+        prolif_fp, interaction_name, jax_result.residue_ids
+    )
+
+    total = jax_arr.size
+    matches = int((jax_arr == prolif_arr).sum())
+    accuracy = matches / total * 100
+
+    assert accuracy == 100.0, (
+        f"{interaction_name}: {accuracy:.1f}% accuracy "
+        f"({total - matches} mismatches out of {total})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# residue_mode="all" captures at least as many residues as "first"
+# ---------------------------------------------------------------------------
+
+
+def test_residue_mode_all_ge_first(u: "Universe"):
+    result_first = analyze_trajectory(
+        u,
+        ligand_selection="resname LIG",
+        protein_selection="protein",
+        residue_mode="first",
+    )
+    result_all = analyze_trajectory(
+        u,
+        ligand_selection="resname LIG",
+        protein_selection="protein",
+        residue_mode="all",
+    )
+    assert result_all.n_residues >= result_first.n_residues
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+
+def test_pairwise_distances():
+    import jax.numpy as jnp
+
+    from prolif.interactions._jax.primitives import pairwise_distances
+
+    coords1 = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    coords2 = jnp.array([[3.0, 0.0, 0.0], [4.0, 0.0, 0.0]])
+    d = pairwise_distances(coords1, coords2)
+    assert d.shape == (2, 2)
+    np.testing.assert_allclose(d[0, 0], 3.0, atol=1e-5)
+    np.testing.assert_allclose(d[0, 1], 4.0, atol=1e-5)
+    np.testing.assert_allclose(d[1, 0], 2.0, atol=1e-5)
+    np.testing.assert_allclose(d[1, 1], 3.0, atol=1e-5)
+
+
+def test_ring_normal_perpendicular():
+    import jax.numpy as jnp
+
+    from prolif.interactions._jax.primitives import ring_normal
+
+    # Simple square ring in the XY plane — normal should be along Z
+    coords = jnp.array([
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [-1.0, 0.0, 0.0],
+        [0.0, -1.0, 0.0],
+    ])
+    indices = jnp.array([0, 1, 2, 3])
+    n = ring_normal(coords, indices)
+    assert n.shape == (3,)
+    # Normal must be perpendicular to the XY-plane vectors
+    np.testing.assert_allclose(abs(float(n[2])), 1.0, atol=1e-5)
+
+
+def test_angle_between_vectors():
+    import jax.numpy as jnp
+
+    from prolif.interactions._jax.primitives import angle_between_vectors
+
+    v1 = jnp.array([1.0, 0.0, 0.0])
+    v2 = jnp.array([0.0, 1.0, 0.0])
+    angle = float(angle_between_vectors(v1, v2))
+    np.testing.assert_allclose(angle, np.pi / 2, atol=1e-5)
+
+    v3 = jnp.array([-1.0, 0.0, 0.0])
+    angle2 = float(angle_between_vectors(v1, v3))
+    np.testing.assert_allclose(angle2, np.pi, atol=1e-5)


### PR DESCRIPTION
This adds a JAX-backed path for computing ProLIF interaction fingerprints over single frames and MDAnalysis trajectories.

The main goal is to speed up repeated frame/residue interaction checks by using JAX batching and JIT compilation, while keeping the results easy to compare with the existing `Fingerprint.run()` workflow. In my own trajectory workloads, this has been a large practical speedup on CPU after the initial JIT compile.

The new code lives under `prolif.interactions._jax` for now, so it is available for testing and iteration without changing the default ProLIF API.

What's different:
- Added JAX batched geometry primitives and frame-level interaction evaluation
- Added high-level `analyze_frame` and `analyze_trajectory` helpers
- Added residue scanning across trajectories so contacts are not limited to the first frame
- Added parity tests against the existing ProLIF fingerprint implementation