### PR TITLE
Fix lignetwork docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ------------
 
-The recommanded way to install ProLIF is to use `conda`_.
+The recommended way to install ProLIF is to use `conda`_.
 
 These first steps are optional and will create a separate environment for ProLIF::
 

--- a/docs/source/modules/plotting.rst
+++ b/docs/source/modules/plotting.rst
@@ -7,4 +7,4 @@ Plotting
 
 .. automodule:: prolif.plotting.complex3d
 
-.. automodule:: prolif.plotting.network
+.. automodule:: prolif.plotting.network.lignetwork

--- a/prolif/io/cif.py
+++ b/prolif/io/cif.py
@@ -4,8 +4,7 @@ I/O-related helper functions --- :mod:`prolif.io.cif`
 This module provides a wrapper around `gemmi` for reading
 Crystallographic Information File (CIF) format.
 
-.. versionchanged:: 2.2.0
-    Replaced the custom CIF parser with a thin wrapper around ``gemmi``.
+.. versionadded:: 2.2.0
 """
 
 from pathlib import Path

--- a/prolif/molecule.py
+++ b/prolif/molecule.py
@@ -146,6 +146,15 @@ class Molecule(BaseRDKitMol):
             mol = prolif.Molecule.from_mda(protein)
             mol
 
+        Since MDAnalysis v2.10.0, it is possible to directly control how bond orders and
+        charges are inferred from the topology using the ``inferrer`` parameter::
+
+            >>> from MDAnalysis.converters.RDKitInferring import TemplateInferrer
+            >>> from rdkit import Chem
+            >>> ligand_template = Chem.MolFromSmiles("NC(c2nc(=Cc1ccc([O-])cc1)c(=O)n2CC=O)C(C)O")
+            >>> ligand_inferrer = TemplateInferrer(ligand_template)
+            >>> mol = prolif.Molecule.from_mda(u, "resname LIG", inferrer=ligand_inferrer)
+
         .. versionchanged:: 2.1.0
             Added `use_segid`.
         """


### PR DESCRIPTION
Fixes:
- API docs for lignetwork not appearing since the refactor in separate files
- copy-paste MDA converter new inferrer param from tutorials into Molecule
- typos