### PR TITLE
Ignore self interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `ignore` parameter in `Fingerprint` to ignore specific pairs of residues.
+  Defaults to ignoring interactions of a residue with itself.
 - Support for `ImplicitHBAcceptor` and `ImplicitHBDonor` interactions to calculate  
   hydrogen bond interactions with merely heavy atoms. This helps users to estimate 
   the hydrogen bond interactions for structures from PDB database or AI-driven

--- a/docs/notebooks/advanced.ipynb
+++ b/docs/notebooks/advanced.ipynb
@@ -564,6 +564,54 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Ignoring specific residue pairs\n",
+    "\n",
+    "By default, ProLIF skips calculating interactions between a residue and itself, which typically happens when calculating interactions of a protein with itself:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fp = plf.Fingerprint([\"HBAcceptor\", \"HBDonor\"])\n",
+    "fp.run_from_iterable([protein_mol], protein_mol)\n",
+    "fp.to_dataframe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can define your own predicate function to decide which residue pairs should be ignored. This can be done through the `ignore` parameter which takes two {class}`~prolif.residue.Residue` objects as input and returns a boolean:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from prolif.residue import Residue\n",
+    "\n",
+    "\n",
+    "def ignore_sequence_neighbours(res1: Residue, res2: Residue) -> bool:\n",
+    "    \"\"\"Skips the pair if they are close in the amino-acid sequence.\"\"\"\n",
+    "    return (\n",
+    "        res1.resid.chain == res2.resid.chain\n",
+    "        and abs(res1.resid.number - res2.resid.number) <= 4\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "fp.run_from_iterable([protein_mol], protein_mol, ignore=ignore_sequence_neighbours)\n",
+    "fp.to_dataframe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Accessing results\n",
     "\n",
     "Once the fingerprint analysis has been run, there are multiple ways to access the data. The most convenient one showcased in the tutorials is through a pandas DataFrame, however this only shows the residues involved in each interaction."
@@ -592,8 +640,8 @@
    "outputs": [],
    "source": [
     "frame_number = 0\n",
-    "ligand_residue = \"UNL1\"\n",
-    "protein_residue = \"VAL200.A\"\n",
+    "ligand_residue = \"TYR40.A\"\n",
+    "protein_residue = \"ASP352.B\"\n",
     "\n",
     "fp.ifp[frame_number][(ligand_residue, protein_residue)]"
    ]

--- a/docs/notebooks/advanced.ipynb
+++ b/docs/notebooks/advanced.ipynb
@@ -584,7 +584,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can define your own predicate function to decide which residue pairs should be ignored. This can be done through the `ignore` parameter which takes two {class}`~prolif.residue.Residue` objects as input and returns a boolean:"
+    "You can define your own predicate function to decide which residue pairs should be ignored. This can be done through the `ignore` parameter of the `Fingerprint` constructor, which takes two {class}`~prolif.residue.Residue` objects as input and returns a boolean:"
    ]
   },
   {
@@ -604,7 +604,8 @@
     "    )\n",
     "\n",
     "\n",
-    "fp.run_from_iterable([protein_mol], protein_mol, ignore=ignore_sequence_neighbours)\n",
+    "fp = plf.Fingerprint([\"HBAcceptor\", \"HBDonor\"], ignore=ignore_sequence_neighbours)\n",
+    "fp.run_from_iterable([protein_mol], protein_mol)\n",
     "fp.to_dataframe()"
    ]
   },

--- a/docs/source/modules/residues.rst
+++ b/docs/source/modules/residues.rst
@@ -9,7 +9,11 @@ Residues
     .. autoclass:: ResidueId
         :members:
 
-    
+    Utilities
+    ---------
+
+    .. autofunction:: ignore_self_interactions
+
     ResidueGroup
     ------------
 

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -26,9 +26,17 @@ Calculate a Protein-Ligand Interaction Fingerprint --- :mod:`prolif.fingerprint`
 """
 
 import warnings
-from collections.abc import Iterable, Sequence, Sized
+from collections.abc import Callable, Iterable, Sequence, Sized
 from inspect import signature
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Optional,
+    Union,
+    cast,
+    overload,
+)
 
 import dill
 import numpy as np
@@ -53,6 +61,7 @@ from prolif.parallel import (
     get_n_jobs,
 )
 from prolif.plotting.utils import IS_NOTEBOOK
+from prolif.residue import Residue, ignore_self_interactions
 from prolif.utils import (
     get_residues_near_ligand,
     to_bitvectors,
@@ -68,7 +77,7 @@ if TYPE_CHECKING:
 
     from prolif.plotting.complex3d import Complex3D
     from prolif.plotting.network import LigNetwork
-    from prolif.residue import Residue, ResidueId
+    from prolif.residue import ResidueId
     from prolif.typeshed import (
         IFPData,
         IFPResults,
@@ -462,6 +471,7 @@ class Fingerprint:
         prot: Molecule,
         residues: "ResidueSelection" = None,
         metadata: Literal[False] = False,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> dict[tuple["ResidueId", "ResidueId"], "NDArray"]: ...
     @overload
     def generate(
@@ -470,6 +480,7 @@ class Fingerprint:
         prot: Molecule,
         residues: "ResidueSelection" = None,
         metadata: Literal[True] = True,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> IFP: ...
     def generate(
         self,
@@ -477,6 +488,7 @@ class Fingerprint:
         prot: Molecule,
         residues: "ResidueSelection" = None,
         metadata: bool = False,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> IFP | dict[tuple["ResidueId", "ResidueId"], "NDArray"]:
         """Generates the interaction fingerprint between 2 molecules
 
@@ -497,6 +509,13 @@ class Fingerprint:
         metadata : bool
             For each residue pair and interaction, return an interaction metadata
             dictionary instead of bits.
+        ignore : Callable[[Residue, Residue], bool]
+            Predicate function that returns ``True`` if the two residues should be
+            skipped when calculating interactions. Default is to ignore interactions
+            between the same residue (see
+            :func:`~prolif.residue.ignore_self_interactions`). Can be used to exclude
+            residue pairs based on :class:`~prolif.residue.ResidueId` attributes, but
+            also by geometric criteria (e.g. residues where any atom clashes).
 
         Returns
         -------
@@ -525,6 +544,9 @@ class Fingerprint:
             dictionary of metadata tuples indexed by interaction name instead of a
             tuple of arrays.
 
+        .. versionchanged:: 2.2.0
+            Added ``ignore`` parameter.
+
         """
         ifp: IFP | dict[tuple["ResidueId", "ResidueId"], "NDArray"] = (
             IFP() if metadata else {}
@@ -541,6 +563,8 @@ class Fingerprint:
                 )
             for prot_key in prot_residues:  # type:ignore[union-attr]
                 pres = prot[prot_key]
+                if ignore(lres, pres):
+                    continue
                 key = (lresid, pres.resid)
                 interactions = get_interactions(lres, pres)
                 if any(interactions):
@@ -558,6 +582,7 @@ class Fingerprint:
         progress: bool = True,
         n_jobs: int | None = None,
         parallel_strategy: Literal["chunk", "queue"] | None = None,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> "Fingerprint":
         """Generates the fingerprint on a trajectory for a ligand and a protein
 
@@ -600,6 +625,13 @@ class Fingerprint:
               atoms.
             - ``None``: See :func:`~prolif.parallel.get_mda_parallel_strategy` for
               the default behavior.
+        ignore : Callable[[Residue, Residue], bool]
+            Predicate function that returns ``True`` if the two residues should be
+            skipped when calculating interactions. Default is to ignore interactions
+            between the same residue (see
+            :func:`~prolif.residue.ignore_self_interactions`). Can be used to exclude
+            residue pairs based on :class:`~prolif.residue.ResidueId` attributes, but
+            also by geometric criteria (e.g. residues where any atom clashes).
 
         Raises
         ------
@@ -647,6 +679,9 @@ class Fingerprint:
             Added ``use_segid``, ``parallel_strategy`` parameter and changed the
             default behavior of ``n_jobs=None``.
 
+        .. versionchanged:: 2.2.0
+            Added ``ignore`` parameter.
+
         """  # noqa: E501
         if converter_kwargs is not None and len(converter_kwargs) != 2:
             raise ValueError("converter_kwargs must be a list of 2 dicts")
@@ -679,6 +714,7 @@ class Fingerprint:
                     residues=residues,
                     converter_kwargs=converter_kwargs,
                     progress=progress,
+                    ignore=ignore,
                 )
             else:
                 ifp = self._run_parallel(
@@ -690,6 +726,7 @@ class Fingerprint:
                     progress=progress,
                     n_jobs=n_jobs,
                     parallel_strategy=parallel_strategy,
+                    ignore=ignore,
                 )
             self.ifp = ifp
 
@@ -704,6 +741,7 @@ class Fingerprint:
                 use_segid=self.use_segid,
                 n_jobs=n_jobs,
                 parallel_strategy=parallel_strategy,
+                ignore=ignore,
             )
         return self
 
@@ -725,6 +763,7 @@ class Fingerprint:
         residues: "ResidueSelection",
         converter_kwargs: tuple[dict, dict],
         progress: bool,
+        ignore: Callable[[Residue, Residue], bool],
         **kwargs: Any,
     ) -> "IFPResults":
         """Serial implementation for trajectories."""
@@ -741,7 +780,7 @@ class Fingerprint:
                 prot, use_segid=self.use_segid, **converter_kwargs[1]
             )
             ifp[int(ts.frame)] = self.generate(
-                lig_mol, prot_mol, residues=residues, metadata=True
+                lig_mol, prot_mol, residues=residues, metadata=True, ignore=ignore
             )
         return ifp
 
@@ -755,6 +794,7 @@ class Fingerprint:
         progress: bool,
         n_jobs: int | None,
         parallel_strategy: Literal["chunk", "queue"],
+        ignore: Callable[[Residue, Residue], bool],
         **kwargs: Any,
     ) -> "IFPResults":
         """Parallel implementation of :meth:`~Fingerprint.run`"""
@@ -785,6 +825,7 @@ class Fingerprint:
                     residues=residues,
                     converter_kwargs=converter_kwargs,
                     progress=progress,
+                    ignore=ignore,
                 )
             else:
                 frames = []
@@ -802,6 +843,7 @@ class Fingerprint:
                 tqdm_kwargs=tqdm_kwargs,
                 rdkitconverter_kwargs=converter_kwargs,
                 use_segid=self.use_segid or False,
+                ignore=ignore,
             ) as pool:
                 return pool.process(traj, lig, prot)
 
@@ -818,6 +860,7 @@ class Fingerprint:
             tqdm_kwargs=tqdm_kwargs,
             rdkitconverter_kwargs=converter_kwargs,
             use_segid=self.use_segid or False,
+            ignore=ignore,
         ) as pool:
             for ifp_data_chunk in pool.process(args_iterable):
                 ifp.update(ifp_data_chunk)
@@ -832,6 +875,7 @@ class Fingerprint:
         residues: "ResidueSelection" = None,
         progress: bool = True,
         n_jobs: int | None = None,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> "Fingerprint":
         """Generates the fingerprint between a list of ligands and a protein
 
@@ -856,6 +900,13 @@ class Fingerprint:
             Number of processes to run in parallel. If ``n_jobs=1``, the
             calculation will run in serial. If ``n_jobs=None``, see
             :func:`~prolif.parallel.get_n_jobs` for the default behavior.
+        ignore : Callable[[Residue, Residue], bool]
+            Predicate function that returns ``True`` if the two residues should be
+            skipped when calculating interactions. Default is to ignore interactions
+            between the same residue (see
+            :func:`~prolif.residue.ignore_self_interactions`). Can be used to exclude
+            residue pairs based on :class:`~prolif.residue.ResidueId` attributes, but
+            also by geometric criteria (e.g. residues where any atom clashes).
 
         Raises
         ------
@@ -897,6 +948,9 @@ class Fingerprint:
         .. versionchanged:: 2.1.0
             Changed the default behavior of ``n_jobs=None``.
 
+        .. versionchanged:: 2.2.0
+            Added ``ignore`` parameter.
+
         """
         if residues == "all":
             residues = list(prot_mol.residues)
@@ -909,6 +963,7 @@ class Fingerprint:
                     prot_mol=prot_mol,
                     residues=residues,
                     progress=progress,
+                    ignore=ignore,
                 )
             else:
                 ifp = self._run_iter_parallel(
@@ -917,6 +972,7 @@ class Fingerprint:
                     residues=residues,
                     progress=progress,
                     n_jobs=n_jobs,
+                    ignore=ignore,
                 )
             self.ifp = ifp
 
@@ -927,6 +983,7 @@ class Fingerprint:
                 residues=residues,
                 progress=progress,
                 n_jobs=n_jobs,
+                ignore=ignore,
             )
 
         return self
@@ -937,12 +994,15 @@ class Fingerprint:
         prot_mol: Molecule,
         residues: "ResidueSelection" = None,
         progress: bool = True,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
         **kwargs: Any,
     ) -> "IFPResults":
         iterator = tqdm(lig_iterable, **kwargs) if progress else lig_iterable
         ifp: "IFPResults" = {}
         for i, lig_mol in enumerate(iterator):
-            ifp[i] = self.generate(lig_mol, prot_mol, residues=residues, metadata=True)
+            ifp[i] = self.generate(
+                lig_mol, prot_mol, residues=residues, metadata=True, ignore=ignore
+            )
         return ifp
 
     def _run_iter_parallel(
@@ -952,6 +1012,7 @@ class Fingerprint:
         residues: "ResidueSelection" = None,
         progress: bool = True,
         n_jobs: int | None = None,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
         **kwargs: Any,
     ) -> "IFPResults":
         """Parallel implementation of :meth:`~Fingerprint.run_from_iterable`"""
@@ -967,6 +1028,7 @@ class Fingerprint:
             fingerprint=self,
             prot_mol=prot_mol,
             residues=residues,
+            ignore=ignore,
             tqdm_kwargs={"total": total, "disable": not progress, **kwargs},
         ) as pool:
             for i, ifp_data in enumerate(pool.process(lig_iterable)):

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -578,91 +578,91 @@ class Fingerprint:
     ) -> "Fingerprint":
         """Generates the fingerprint on a trajectory for a ligand and a protein
 
-        Parameters
-        ----------
-        traj : MDAnalysis.coordinates.base.ProtoReader or MDAnalysis.coordinates.base.FrameIteratorSliced or MDAnalysis.coordinates.base.FrameIteratorIndices or MDAnalysis.coordinates.timestep.Timestep
-            Iterate over this Universe trajectory or sliced trajectory object
-            to extract the frames used for the fingerprint extraction
-        lig : MDAnalysis.core.groups.AtomGroup
-            An MDAnalysis AtomGroup for the ligand
-        prot : MDAnalysis.core.groups.AtomGroup
-            An MDAnalysis AtomGroup for the protein (with multiple residues)
-        residues : list or "all" or None
-            A list of protein residues (:class:`str`, :class:`int` or
-            :class:`~prolif.residue.ResidueId`) to take into account for
-            the fingerprint extraction. If ``"all"``, all residues will be
-            used. If ``None``, at each frame the
-            :func:`~prolif.utils.get_residues_near_ligand` function is used to
-            automatically use protein residues that are distant of 6.0 Å or
-            less from each ligand residue.
-        converter_kwargs : tuple[dict, dict], optional
-            Tuple of kwargs passed to the underlying
-            :class:`~MDAnalysis.converters.RDKit.RDKitConverter` from MDAnalysis: the
-            first for the ligand, and the second for the protein
-        progress : bool
-            Display a :class:`~tqdm.std.tqdm` progressbar while running the calculation
-        n_jobs : int or None
-            Number of processes to run in parallel. If ``n_jobs=1``, the analysis
-            will run in serial. If ``n_jobs=None``, see
-            :func:`~prolif.parallel.get_n_jobs` for the default behavior.
-        parallel_strategy : {"chunk", "queue"}, optional
-            Strategy for parallel execution:
+                Parameters
+                ----------
+                traj : MDAnalysis.coordinates.base.ProtoReader or MDAnalysis.coordinates.base.FrameIteratorSliced or MDAnalysis.coordinates.base.FrameIteratorIndices or MDAnalysis.coordinates.timestep.Timestep
+                    Iterate over this Universe trajectory or sliced trajectory object
+                    to extract the frames used for the fingerprint extraction
+                lig : MDAnalysis.core.groups.AtomGroup
+                    An MDAnalysis AtomGroup for the ligand
+                prot : MDAnalysis.core.groups.AtomGroup
+                    An MDAnalysis AtomGroup for the protein (with multiple residues)
+                residues : list or "all" or None
+                    A list of protein residues (:class:`str`, :class:`int` or
+                    :class:`~prolif.residue.ResidueId`) to take into account for
+                    the fingerprint extraction. If ``"all"``, all residues will be
+                    used. If ``None``, at each frame the
+                    :func:`~prolif.utils.get_residues_near_ligand` function is used to
+                    automatically use protein residues that are distant of 6.0 Å or
+                    less from each ligand residue.
+                converter_kwargs : tuple[dict, dict], optional
+                    Tuple of kwargs passed to the underlying
+                    :class:`~MDAnalysis.converters.RDKit.RDKitConverter` from MDAnalysis: the
+                    first for the ligand, and the second for the protein
+                progress : bool
+                    Display a :class:`~tqdm.std.tqdm` progressbar while running the calculation
+                n_jobs : int or None
+                    Number of processes to run in parallel. If ``n_jobs=1``, the analysis
+                    will run in serial. If ``n_jobs=None``, see
+                    :func:`~prolif.parallel.get_n_jobs` for the default behavior.
+                parallel_strategy : {"chunk", "queue"}, optional
+                    Strategy for parallel execution:
 
-            - ``"chunk"``: Split trajectory into chunks and distribute to workers.
-              Each worker pickles the full MDAnalysis objects once per chunk.
-              Scales better for small trajectories.
-            - ``"queue"``: Main thread converts frames to Molecules and enqueues
-              them for workers. Avoids repeated MDAnalysis pickling overhead.
-              Better when pickling is expensive, e.g. large trajectories with many
-              atoms.
-            - ``None``: See :func:`~prolif.parallel.get_mda_parallel_strategy` for
-              the default behavior.
+                    - ``"chunk"``: Split trajectory into chunks and distribute to workers.
+                      Each worker pickles the full MDAnalysis objects once per chunk.
+                      Scales better for small trajectories.
+                    - ``"queue"``: Main thread converts frames to Molecules and enqueues
+                      them for workers. Avoids repeated MDAnalysis pickling overhead.
+                      Better when pickling is expensive, e.g. large trajectories with many
+                      atoms.
+                    - ``None``: See :func:`~prolif.parallel.get_mda_parallel_strategy` for
+                      the default behavior.
 
-        Raises
-------
-        ValueError
-            If ``n_jobs <= 0``
+                Raises
+        ------
+                ValueError
+                    If ``n_jobs <= 0``
 
-        Returns
-        -------
-        prolif.fingerprint.Fingerprint
-            The Fingerprint instance that generated the fingerprint
+                Returns
+                -------
+                prolif.fingerprint.Fingerprint
+                    The Fingerprint instance that generated the fingerprint
 
-        Example
-        -------
-        ::
+                Example
+                -------
+                ::
 
-            >>> u = mda.Universe("top.pdb", "traj.nc")
-            >>> lig = u.select_atoms("resname LIG")
-            >>> prot = u.select_atoms("protein")
-            >>> fp = prolif.Fingerprint().run(u.trajectory[:10], lig, prot)
+                    >>> u = mda.Universe("top.pdb", "traj.nc")
+                    >>> lig = u.select_atoms("resname LIG")
+                    >>> prot = u.select_atoms("protein")
+                    >>> fp = prolif.Fingerprint().run(u.trajectory[:10], lig, prot)
 
-        .. seealso::
+                .. seealso::
 
-            - :meth:`Fingerprint.generate` to generate the fingerprint between
-              two single structures.
-            - :meth:`Fingerprint.run_from_iterable` to generate the fingerprint
-              between a protein and a collection of ligands.
+                    - :meth:`Fingerprint.generate` to generate the fingerprint between
+                      two single structures.
+                    - :meth:`Fingerprint.run_from_iterable` to generate the fingerprint
+                      between a protein and a collection of ligands.
 
-        .. versionchanged:: 0.3.2
-            Moved the ``return_atoms`` parameter from the ``run`` method to the
-            dataframe conversion code
+                .. versionchanged:: 0.3.2
+                    Moved the ``return_atoms`` parameter from the ``run`` method to the
+                    dataframe conversion code
 
-        .. versionchanged:: 1.0.0
-            Added support for multiprocessing
+                .. versionchanged:: 1.0.0
+                    Added support for multiprocessing
 
-        .. versionchanged:: 1.1.0
-            Added support for passing kwargs to the RDKitConverter through
-            the ``converter_kwargs`` parameter
+                .. versionchanged:: 1.1.0
+                    Added support for passing kwargs to the RDKitConverter through
+                    the ``converter_kwargs`` parameter
 
-        .. versionchanged:: 2.0.0
-            Changed the format of the :attr:`~Fingerprint.ifp` attribute to be a
-            dictionary containing more complete interaction metadata instead of just
-            atom indices.
+                .. versionchanged:: 2.0.0
+                    Changed the format of the :attr:`~Fingerprint.ifp` attribute to be a
+                    dictionary containing more complete interaction metadata instead of just
+                    atom indices.
 
-        .. versionchanged:: 2.1.0
-            Added ``use_segid``, ``parallel_strategy`` parameter and changed the
-            default behavior of ``n_jobs=None``.
+                .. versionchanged:: 2.1.0
+                    Added ``use_segid``, ``parallel_strategy`` parameter and changed the
+                    default behavior of ``n_jobs=None``.
 
         """  # noqa: E501
         if converter_kwargs is not None and len(converter_kwargs) != 2:
@@ -959,9 +959,7 @@ class Fingerprint:
         iterator = tqdm(lig_iterable, **kwargs) if progress else lig_iterable
         ifp: "IFPResults" = {}
         for i, lig_mol in enumerate(iterator):
-            ifp[i] = self.generate(
-                lig_mol, prot_mol, residues=residues, metadata=True
-            )
+            ifp[i] = self.generate(lig_mol, prot_mol, residues=residues, metadata=True)
         return ifp
 
     def _run_iter_parallel(

--- a/prolif/fingerprint.py
+++ b/prolif/fingerprint.py
@@ -140,6 +140,10 @@ class Fingerprint:
     implicit_hydrogens : bool
         Whether to use interactions compatible with implicit hydrogens instead of the
         default explicit hydrogen-based ones.
+    ignore : Callable[[Residue, Residue], bool]
+        Predicate function that returns ``True`` if the two residues should be
+        skipped when calculating interactions. Default is to ignore interactions
+        between the same residue (see :func:`~prolif.residue.ignore_self_interactions`).
 
     Attributes
     ----------
@@ -254,7 +258,7 @@ class Fingerprint:
 
     .. versionchanged:: 2.2.0
         Added ``implicit_hydrogens`` for easily switching to implicit-hydrogen
-        interactions.
+        interactions. Added ``ignore`` parameter.
     """
 
     def __init__(
@@ -265,6 +269,7 @@ class Fingerprint:
         vicinity_cutoff: float = 6.0,
         use_segid: bool | None = None,
         implicit_hydrogens: bool = False,
+        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> None:
         if interactions is None:
             interactions = DEFAULT_INTERACTIONS
@@ -295,6 +300,7 @@ class Fingerprint:
             interactions = temp_interactions
 
         self.count = count
+        self.ignore = ignore
         self._set_interactions(interactions, parameters)
         self.vicinity_cutoff = vicinity_cutoff
         self.parameters = parameters
@@ -471,7 +477,6 @@ class Fingerprint:
         prot: Molecule,
         residues: "ResidueSelection" = None,
         metadata: Literal[False] = False,
-        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> dict[tuple["ResidueId", "ResidueId"], "NDArray"]: ...
     @overload
     def generate(
@@ -480,7 +485,6 @@ class Fingerprint:
         prot: Molecule,
         residues: "ResidueSelection" = None,
         metadata: Literal[True] = True,
-        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> IFP: ...
     def generate(
         self,
@@ -488,7 +492,6 @@ class Fingerprint:
         prot: Molecule,
         residues: "ResidueSelection" = None,
         metadata: bool = False,
-        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> IFP | dict[tuple["ResidueId", "ResidueId"], "NDArray"]:
         """Generates the interaction fingerprint between 2 molecules
 
@@ -509,13 +512,6 @@ class Fingerprint:
         metadata : bool
             For each residue pair and interaction, return an interaction metadata
             dictionary instead of bits.
-        ignore : Callable[[Residue, Residue], bool]
-            Predicate function that returns ``True`` if the two residues should be
-            skipped when calculating interactions. Default is to ignore interactions
-            between the same residue (see
-            :func:`~prolif.residue.ignore_self_interactions`). Can be used to exclude
-            residue pairs based on :class:`~prolif.residue.ResidueId` attributes, but
-            also by geometric criteria (e.g. residues where any atom clashes).
 
         Returns
         -------
@@ -544,9 +540,6 @@ class Fingerprint:
             dictionary of metadata tuples indexed by interaction name instead of a
             tuple of arrays.
 
-        .. versionchanged:: 2.2.0
-            Added ``ignore`` parameter.
-
         """
         ifp: IFP | dict[tuple["ResidueId", "ResidueId"], "NDArray"] = (
             IFP() if metadata else {}
@@ -563,7 +556,7 @@ class Fingerprint:
                 )
             for prot_key in prot_residues:  # type:ignore[union-attr]
                 pres = prot[prot_key]
-                if ignore(lres, pres):
+                if self.ignore(lres, pres):
                     continue
                 key = (lresid, pres.resid)
                 interactions = get_interactions(lres, pres)
@@ -582,7 +575,6 @@ class Fingerprint:
         progress: bool = True,
         n_jobs: int | None = None,
         parallel_strategy: Literal["chunk", "queue"] | None = None,
-        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> "Fingerprint":
         """Generates the fingerprint on a trajectory for a ligand and a protein
 
@@ -625,16 +617,9 @@ class Fingerprint:
               atoms.
             - ``None``: See :func:`~prolif.parallel.get_mda_parallel_strategy` for
               the default behavior.
-        ignore : Callable[[Residue, Residue], bool]
-            Predicate function that returns ``True`` if the two residues should be
-            skipped when calculating interactions. Default is to ignore interactions
-            between the same residue (see
-            :func:`~prolif.residue.ignore_self_interactions`). Can be used to exclude
-            residue pairs based on :class:`~prolif.residue.ResidueId` attributes, but
-            also by geometric criteria (e.g. residues where any atom clashes).
 
         Raises
-        ------
+------
         ValueError
             If ``n_jobs <= 0``
 
@@ -679,9 +664,6 @@ class Fingerprint:
             Added ``use_segid``, ``parallel_strategy`` parameter and changed the
             default behavior of ``n_jobs=None``.
 
-        .. versionchanged:: 2.2.0
-            Added ``ignore`` parameter.
-
         """  # noqa: E501
         if converter_kwargs is not None and len(converter_kwargs) != 2:
             raise ValueError("converter_kwargs must be a list of 2 dicts")
@@ -714,7 +696,6 @@ class Fingerprint:
                     residues=residues,
                     converter_kwargs=converter_kwargs,
                     progress=progress,
-                    ignore=ignore,
                 )
             else:
                 ifp = self._run_parallel(
@@ -726,7 +707,6 @@ class Fingerprint:
                     progress=progress,
                     n_jobs=n_jobs,
                     parallel_strategy=parallel_strategy,
-                    ignore=ignore,
                 )
             self.ifp = ifp
 
@@ -741,7 +721,6 @@ class Fingerprint:
                 use_segid=self.use_segid,
                 n_jobs=n_jobs,
                 parallel_strategy=parallel_strategy,
-                ignore=ignore,
             )
         return self
 
@@ -763,7 +742,6 @@ class Fingerprint:
         residues: "ResidueSelection",
         converter_kwargs: tuple[dict, dict],
         progress: bool,
-        ignore: Callable[[Residue, Residue], bool],
         **kwargs: Any,
     ) -> "IFPResults":
         """Serial implementation for trajectories."""
@@ -780,7 +758,7 @@ class Fingerprint:
                 prot, use_segid=self.use_segid, **converter_kwargs[1]
             )
             ifp[int(ts.frame)] = self.generate(
-                lig_mol, prot_mol, residues=residues, metadata=True, ignore=ignore
+                lig_mol, prot_mol, residues=residues, metadata=True
             )
         return ifp
 
@@ -794,7 +772,6 @@ class Fingerprint:
         progress: bool,
         n_jobs: int | None,
         parallel_strategy: Literal["chunk", "queue"],
-        ignore: Callable[[Residue, Residue], bool],
         **kwargs: Any,
     ) -> "IFPResults":
         """Parallel implementation of :meth:`~Fingerprint.run`"""
@@ -825,7 +802,6 @@ class Fingerprint:
                     residues=residues,
                     converter_kwargs=converter_kwargs,
                     progress=progress,
-                    ignore=ignore,
                 )
             else:
                 frames = []
@@ -843,7 +819,6 @@ class Fingerprint:
                 tqdm_kwargs=tqdm_kwargs,
                 rdkitconverter_kwargs=converter_kwargs,
                 use_segid=self.use_segid or False,
-                ignore=ignore,
             ) as pool:
                 return pool.process(traj, lig, prot)
 
@@ -860,7 +835,6 @@ class Fingerprint:
             tqdm_kwargs=tqdm_kwargs,
             rdkitconverter_kwargs=converter_kwargs,
             use_segid=self.use_segid or False,
-            ignore=ignore,
         ) as pool:
             for ifp_data_chunk in pool.process(args_iterable):
                 ifp.update(ifp_data_chunk)
@@ -875,7 +849,6 @@ class Fingerprint:
         residues: "ResidueSelection" = None,
         progress: bool = True,
         n_jobs: int | None = None,
-        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
     ) -> "Fingerprint":
         """Generates the fingerprint between a list of ligands and a protein
 
@@ -900,13 +873,6 @@ class Fingerprint:
             Number of processes to run in parallel. If ``n_jobs=1``, the
             calculation will run in serial. If ``n_jobs=None``, see
             :func:`~prolif.parallel.get_n_jobs` for the default behavior.
-        ignore : Callable[[Residue, Residue], bool]
-            Predicate function that returns ``True`` if the two residues should be
-            skipped when calculating interactions. Default is to ignore interactions
-            between the same residue (see
-            :func:`~prolif.residue.ignore_self_interactions`). Can be used to exclude
-            residue pairs based on :class:`~prolif.residue.ResidueId` attributes, but
-            also by geometric criteria (e.g. residues where any atom clashes).
 
         Raises
         ------
@@ -948,9 +914,6 @@ class Fingerprint:
         .. versionchanged:: 2.1.0
             Changed the default behavior of ``n_jobs=None``.
 
-        .. versionchanged:: 2.2.0
-            Added ``ignore`` parameter.
-
         """
         if residues == "all":
             residues = list(prot_mol.residues)
@@ -963,7 +926,6 @@ class Fingerprint:
                     prot_mol=prot_mol,
                     residues=residues,
                     progress=progress,
-                    ignore=ignore,
                 )
             else:
                 ifp = self._run_iter_parallel(
@@ -972,7 +934,6 @@ class Fingerprint:
                     residues=residues,
                     progress=progress,
                     n_jobs=n_jobs,
-                    ignore=ignore,
                 )
             self.ifp = ifp
 
@@ -983,7 +944,6 @@ class Fingerprint:
                 residues=residues,
                 progress=progress,
                 n_jobs=n_jobs,
-                ignore=ignore,
             )
 
         return self
@@ -994,14 +954,13 @@ class Fingerprint:
         prot_mol: Molecule,
         residues: "ResidueSelection" = None,
         progress: bool = True,
-        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
         **kwargs: Any,
     ) -> "IFPResults":
         iterator = tqdm(lig_iterable, **kwargs) if progress else lig_iterable
         ifp: "IFPResults" = {}
         for i, lig_mol in enumerate(iterator):
             ifp[i] = self.generate(
-                lig_mol, prot_mol, residues=residues, metadata=True, ignore=ignore
+                lig_mol, prot_mol, residues=residues, metadata=True
             )
         return ifp
 
@@ -1012,7 +971,6 @@ class Fingerprint:
         residues: "ResidueSelection" = None,
         progress: bool = True,
         n_jobs: int | None = None,
-        ignore: Callable[[Residue, Residue], bool] = ignore_self_interactions,
         **kwargs: Any,
     ) -> "IFPResults":
         """Parallel implementation of :meth:`~Fingerprint.run_from_iterable`"""
@@ -1028,7 +986,6 @@ class Fingerprint:
             fingerprint=self,
             prot_mol=prot_mol,
             residues=residues,
-            ignore=ignore,
             tqdm_kwargs={"total": total, "disable": not progress, **kwargs},
         ) as pool:
             for i, ifp_data in enumerate(pool.process(lig_iterable)):
@@ -1059,7 +1016,7 @@ class Fingerprint:
         """  # noqa: E501
         self.ifp = cast("IFPResults", getattr(self, "ifp", {}))
         for interaction in self.bridged_interactions.values():
-            interaction.setup(ifp_store=self.ifp, **kwargs)
+            interaction.setup(ifp_store=self.ifp, ignore=self.ignore, **kwargs)
             interaction.run(traj, lig, prot)
         return self
 
@@ -1078,7 +1035,7 @@ class Fingerprint:
         """
         self.ifp = getattr(self, "ifp", {})
         for interaction in self.bridged_interactions.values():
-            interaction.setup(ifp_store=self.ifp, **kwargs)
+            interaction.setup(ifp_store=self.ifp, ignore=self.ignore, **kwargs)
             interaction.run_from_iterable(lig_iterable, prot_mol)
         return self
 

--- a/prolif/interactions/water_bridge.py
+++ b/prolif/interactions/water_bridge.py
@@ -110,6 +110,7 @@ class WaterBridge(BridgedInteraction):
         self.residues = self.kwargs.pop("residues", None)
         self.converter_kwargs = self.kwargs.pop("converter_kwargs", ({}, {}))
         self.water_fp.use_segid = self.kwargs.pop("use_segid", False)
+        self.water_fp.ignore = self.kwargs.pop("ignore", self.water_fp.ignore)
 
     def run(
         self,

--- a/prolif/molecule.py
+++ b/prolif/molecule.py
@@ -157,7 +157,7 @@ class Molecule(BaseRDKitMol):
 
         .. versionchanged:: 2.1.0
             Added `use_segid`.
-        """
+        """  # noqa: E501
         ag = obj.select_atoms(selection) if selection else obj.atoms
         if ag.n_atoms == 0:
             raise mda.SelectionError("AtomGroup is empty, please check your selection")

--- a/prolif/parallel.py
+++ b/prolif/parallel.py
@@ -50,7 +50,7 @@ parameter or the ``PROLIF_N_JOBS`` env variable.
 """
 
 import os
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from ctypes import c_uint32
 from threading import Event, Thread
 from time import sleep
@@ -64,6 +64,7 @@ from tqdm.auto import tqdm
 
 from prolif.molecule import Molecule
 from prolif.pickling import PICKLE_HANDLER
+from prolif.residue import Residue
 
 if TYPE_CHECKING:
     from multiprocessing.pool import Pool as BuiltinPool
@@ -198,6 +199,9 @@ class TrajectoryPool:
         from MDAnalysis: the first for the ligand, and the second for the protein
     use_segid: bool
         Use the segment number rather than the chain identifier as a chain.
+    ignore: Callable[[Residue, Residue], bool]
+        Function that returns True if the interaction should be ignored.
+        By default, self-interactions are ignored.
 
     Attributes
     ----------
@@ -207,15 +211,20 @@ class TrajectoryPool:
     pool : multiprocess.pool.Pool
         The underlying pool instance.
 
+
     .. versionchanged:: 2.1.0
         Added `use_segid`.
+
+    .. versionchanged:: 2.2.0
+        Added `ignore`.
     """
 
     tracker: ClassVar["Synchronized"] = cast("Synchronized", Value(c_uint32, lock=True))
     fp: ClassVar["Fingerprint"]
     residues: ClassVar["ResidueSelection"]
     converter_kwargs: ClassVar[tuple[dict, dict]]
-    use_segid: bool
+    use_segid: ClassVar[bool]
+    ignore: ClassVar[Callable[[Residue, Residue], bool]]
 
     def __init__(
         self,
@@ -225,6 +234,7 @@ class TrajectoryPool:
         tqdm_kwargs: dict,
         rdkitconverter_kwargs: tuple[dict, dict],
         use_segid: bool,
+        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         self.tqdm_kwargs = tqdm_kwargs
         self.pool = cast(
@@ -238,6 +248,7 @@ class TrajectoryPool:
                     residues,
                     rdkitconverter_kwargs,
                     use_segid,
+                    ignore,
                 ),
             ),
         )
@@ -250,6 +261,7 @@ class TrajectoryPool:
         residues: "ResidueSelection",
         rdkitconverter_kwargs: tuple[dict, dict],
         use_segid: bool,
+        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         """Initializer classmethod passed to the pool so that each child process can
         access these objects without copying them."""
@@ -258,6 +270,7 @@ class TrajectoryPool:
         cls.residues = residues
         cls.converter_kwargs = rdkitconverter_kwargs
         cls.use_segid = use_segid
+        cls.ignore = ignore
 
     @classmethod
     def executor(
@@ -284,6 +297,7 @@ class TrajectoryPool:
                 prot_mol,
                 residues=cls.residues,
                 metadata=True,
+                ignore=cls.ignore,
             )
             ifp[int(ts.frame)] = data
             with cls.tracker.get_lock():
@@ -344,16 +358,24 @@ class MolIterablePool:
         List of protein residues considered for the IFP
     tqdm_kwargs : dict
         Parameters for the :class:`~tqdm.std.tqdm` progress bar
+    ignore: Callable[[Residue, Residue], bool]
+        Function that returns True if the interaction should be ignored.
+        By default, self-interactions are ignored.
 
     Attributes
     ----------
     pool : multiprocess.pool.Pool
         The underlying pool instance.
+
+
+    .. versionchanged:: 2.2.0
+        Added `ignore`.
     """
 
     fp: ClassVar["Fingerprint"]
     pmol: ClassVar[Molecule]
     residues: ClassVar["ResidueSelection"]
+    ignore: ClassVar[Callable[[Residue, Residue], bool]]
 
     def __init__(
         self,
@@ -361,6 +383,7 @@ class MolIterablePool:
         fingerprint: "Fingerprint",
         prot_mol: Molecule,
         residues: "ResidueSelection",
+        ignore: Callable[[Residue, Residue], bool],
         tqdm_kwargs: dict,
     ) -> None:
         self.tqdm_kwargs = tqdm_kwargs
@@ -369,7 +392,7 @@ class MolIterablePool:
             Pool(
                 n_processes,
                 initializer=self.initializer,
-                initargs=(fingerprint, prot_mol, residues),
+                initargs=(fingerprint, prot_mol, residues, ignore),
             ),
         )
 
@@ -379,12 +402,14 @@ class MolIterablePool:
         fingerprint: "Fingerprint",
         prot_mol: Molecule,
         residues: "ResidueSelection",
+        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         """Initializer classmethod passed to the pool so that each child process can
         access these objects without copying them."""
         cls.fp = fingerprint
         cls.pmol = prot_mol
         cls.residues = residues
+        cls.ignore = ignore
 
     @classmethod
     def executor(cls, mol: Molecule) -> "IFP":
@@ -397,7 +422,9 @@ class MolIterablePool:
             A dictionary indexed by ``(ligand, protein)`` residue pairs, and each value
             is a sparse dictionary of metadata indexed by interaction name.
         """
-        return cls.fp.generate(mol, cls.pmol, residues=cls.residues, metadata=True)
+        return cls.fp.generate(
+            mol, cls.pmol, residues=cls.residues, metadata=True, ignore=cls.ignore
+        )
 
     def process(self, args_iterable: Iterable[Molecule]) -> Iterable["IFP"]:
         """Maps the input iterable of molecules to the executor function.
@@ -450,12 +477,20 @@ class TrajectoryPoolQueue:
         from MDAnalysis: the first for the ligand, and the second for the protein
     use_segid: bool
         Use the segment number rather than the chain identifier as a chain.
+    ignore: Callable[[Residue, Residue], bool]
+        Function that returns True if the interaction should be ignored.
+        By default, self-interactions are ignored.
+
 
     .. versionadded:: 2.1.0
+
+    .. versionchanged:: 2.2.0
+        Added `ignore`.
     """
 
     fp: ClassVar["Fingerprint"]
     residues: ClassVar["ResidueSelection"]
+    ignore: ClassVar[Callable[[Residue, Residue], bool]]
 
     def __init__(
         self,
@@ -465,6 +500,7 @@ class TrajectoryPoolQueue:
         tqdm_kwargs: dict,
         rdkitconverter_kwargs: tuple[dict, dict],
         use_segid: bool,
+        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         self.n_processes = n_processes
         self.tqdm_kwargs = tqdm_kwargs
@@ -475,7 +511,7 @@ class TrajectoryPoolQueue:
             Pool(
                 n_processes,
                 initializer=self.initializer,
-                initargs=(fingerprint, residues),
+                initargs=(fingerprint, residues, ignore),
             ),
         )
 
@@ -484,11 +520,13 @@ class TrajectoryPoolQueue:
         cls,
         fingerprint: "Fingerprint",
         residues: "ResidueSelection",
+        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         """Initializer classmethod passed to the pool so that each child process can
         access these objects without copying them."""
         cls.fp = fingerprint
         cls.residues = residues
+        cls.ignore = ignore
 
     @classmethod
     def executor(cls, args: tuple[int, Molecule, Molecule]) -> tuple[int, "IFP"]:
@@ -510,6 +548,7 @@ class TrajectoryPoolQueue:
             prot_mol,
             residues=cls.residues,
             metadata=True,
+            ignore=cls.ignore,
         )
         return frame, data
 

--- a/prolif/parallel.py
+++ b/prolif/parallel.py
@@ -458,8 +458,6 @@ class TrajectoryPoolQueue:
 
     .. versionadded:: 2.1.0
 
-    .. versionchanged:: 2.2.0
-        Added ``ignore`` parameter to :class:`~prolif.fingerprint.Fingerprint` constructor.
     """
 
     fp: ClassVar["Fingerprint"]

--- a/prolif/parallel.py
+++ b/prolif/parallel.py
@@ -50,7 +50,7 @@ parameter or the ``PROLIF_N_JOBS`` env variable.
 """
 
 import os
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from ctypes import c_uint32
 from threading import Event, Thread
 from time import sleep
@@ -64,7 +64,6 @@ from tqdm.auto import tqdm
 
 from prolif.molecule import Molecule
 from prolif.pickling import PICKLE_HANDLER
-from prolif.residue import Residue
 
 if TYPE_CHECKING:
     from multiprocessing.pool import Pool as BuiltinPool
@@ -199,9 +198,6 @@ class TrajectoryPool:
         from MDAnalysis: the first for the ligand, and the second for the protein
     use_segid: bool
         Use the segment number rather than the chain identifier as a chain.
-    ignore: Callable[[Residue, Residue], bool]
-        Function that returns True if the interaction should be ignored.
-        By default, self-interactions are ignored.
 
     Attributes
     ----------
@@ -215,8 +211,6 @@ class TrajectoryPool:
     .. versionchanged:: 2.1.0
         Added `use_segid`.
 
-    .. versionchanged:: 2.2.0
-        Added `ignore`.
     """
 
     tracker: ClassVar["Synchronized"] = cast("Synchronized", Value(c_uint32, lock=True))
@@ -224,7 +218,6 @@ class TrajectoryPool:
     residues: ClassVar["ResidueSelection"]
     converter_kwargs: ClassVar[tuple[dict, dict]]
     use_segid: ClassVar[bool]
-    ignore: ClassVar[Callable[[Residue, Residue], bool]]
 
     def __init__(
         self,
@@ -234,7 +227,6 @@ class TrajectoryPool:
         tqdm_kwargs: dict,
         rdkitconverter_kwargs: tuple[dict, dict],
         use_segid: bool,
-        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         self.tqdm_kwargs = tqdm_kwargs
         self.pool = cast(
@@ -248,7 +240,6 @@ class TrajectoryPool:
                     residues,
                     rdkitconverter_kwargs,
                     use_segid,
-                    ignore,
                 ),
             ),
         )
@@ -261,7 +252,6 @@ class TrajectoryPool:
         residues: "ResidueSelection",
         rdkitconverter_kwargs: tuple[dict, dict],
         use_segid: bool,
-        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         """Initializer classmethod passed to the pool so that each child process can
         access these objects without copying them."""
@@ -270,7 +260,6 @@ class TrajectoryPool:
         cls.residues = residues
         cls.converter_kwargs = rdkitconverter_kwargs
         cls.use_segid = use_segid
-        cls.ignore = ignore
 
     @classmethod
     def executor(
@@ -297,7 +286,6 @@ class TrajectoryPool:
                 prot_mol,
                 residues=cls.residues,
                 metadata=True,
-                ignore=cls.ignore,
             )
             ifp[int(ts.frame)] = data
             with cls.tracker.get_lock():
@@ -358,9 +346,6 @@ class MolIterablePool:
         List of protein residues considered for the IFP
     tqdm_kwargs : dict
         Parameters for the :class:`~tqdm.std.tqdm` progress bar
-    ignore: Callable[[Residue, Residue], bool]
-        Function that returns True if the interaction should be ignored.
-        By default, self-interactions are ignored.
 
     Attributes
     ----------
@@ -368,14 +353,11 @@ class MolIterablePool:
         The underlying pool instance.
 
 
-    .. versionchanged:: 2.2.0
-        Added `ignore`.
     """
 
     fp: ClassVar["Fingerprint"]
     pmol: ClassVar[Molecule]
     residues: ClassVar["ResidueSelection"]
-    ignore: ClassVar[Callable[[Residue, Residue], bool]]
 
     def __init__(
         self,
@@ -383,7 +365,6 @@ class MolIterablePool:
         fingerprint: "Fingerprint",
         prot_mol: Molecule,
         residues: "ResidueSelection",
-        ignore: Callable[[Residue, Residue], bool],
         tqdm_kwargs: dict,
     ) -> None:
         self.tqdm_kwargs = tqdm_kwargs
@@ -392,7 +373,7 @@ class MolIterablePool:
             Pool(
                 n_processes,
                 initializer=self.initializer,
-                initargs=(fingerprint, prot_mol, residues, ignore),
+                initargs=(fingerprint, prot_mol, residues),
             ),
         )
 
@@ -402,14 +383,12 @@ class MolIterablePool:
         fingerprint: "Fingerprint",
         prot_mol: Molecule,
         residues: "ResidueSelection",
-        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         """Initializer classmethod passed to the pool so that each child process can
         access these objects without copying them."""
         cls.fp = fingerprint
         cls.pmol = prot_mol
         cls.residues = residues
-        cls.ignore = ignore
 
     @classmethod
     def executor(cls, mol: Molecule) -> "IFP":
@@ -422,9 +401,7 @@ class MolIterablePool:
             A dictionary indexed by ``(ligand, protein)`` residue pairs, and each value
             is a sparse dictionary of metadata indexed by interaction name.
         """
-        return cls.fp.generate(
-            mol, cls.pmol, residues=cls.residues, metadata=True, ignore=cls.ignore
-        )
+        return cls.fp.generate(mol, cls.pmol, residues=cls.residues, metadata=True)
 
     def process(self, args_iterable: Iterable[Molecule]) -> Iterable["IFP"]:
         """Maps the input iterable of molecules to the executor function.
@@ -477,20 +454,16 @@ class TrajectoryPoolQueue:
         from MDAnalysis: the first for the ligand, and the second for the protein
     use_segid: bool
         Use the segment number rather than the chain identifier as a chain.
-    ignore: Callable[[Residue, Residue], bool]
-        Function that returns True if the interaction should be ignored.
-        By default, self-interactions are ignored.
 
 
     .. versionadded:: 2.1.0
 
     .. versionchanged:: 2.2.0
-        Added `ignore`.
+        Added ``ignore`` parameter to :class:`~prolif.fingerprint.Fingerprint` constructor.
     """
 
     fp: ClassVar["Fingerprint"]
     residues: ClassVar["ResidueSelection"]
-    ignore: ClassVar[Callable[[Residue, Residue], bool]]
 
     def __init__(
         self,
@@ -500,7 +473,6 @@ class TrajectoryPoolQueue:
         tqdm_kwargs: dict,
         rdkitconverter_kwargs: tuple[dict, dict],
         use_segid: bool,
-        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         self.n_processes = n_processes
         self.tqdm_kwargs = tqdm_kwargs
@@ -511,7 +483,7 @@ class TrajectoryPoolQueue:
             Pool(
                 n_processes,
                 initializer=self.initializer,
-                initargs=(fingerprint, residues, ignore),
+                initargs=(fingerprint, residues),
             ),
         )
 
@@ -520,13 +492,11 @@ class TrajectoryPoolQueue:
         cls,
         fingerprint: "Fingerprint",
         residues: "ResidueSelection",
-        ignore: Callable[[Residue, Residue], bool],
     ) -> None:
         """Initializer classmethod passed to the pool so that each child process can
         access these objects without copying them."""
         cls.fp = fingerprint
         cls.residues = residues
-        cls.ignore = ignore
 
     @classmethod
     def executor(cls, args: tuple[int, Molecule, Molecule]) -> tuple[int, "IFP"]:
@@ -548,7 +518,6 @@ class TrajectoryPoolQueue:
             prot_mol,
             residues=cls.residues,
             metadata=True,
-            ignore=cls.ignore,
         )
         return frame, data
 

--- a/prolif/residue.py
+++ b/prolif/residue.py
@@ -289,3 +289,28 @@ class ResidueGroup(UserDict[ResidueId, Residue]):
     @property
     def n_residues(self) -> int:
         return len(self)
+
+
+def ignore_self_interactions(
+    res1: Residue,
+    res2: Residue,
+) -> bool:
+    """
+    Ignore interactions between the same residue
+
+    Parameters
+    ----------
+    res1 : Residue
+        The first residue
+    res2 : Residue
+        The second residue
+
+    Returns
+    -------
+    bool
+        ``True`` if the residues are the same, ``False`` otherwise.
+
+
+    .. versionadded:: 2.2.0
+    """
+    return res1.resid == res2.resid

--- a/prolif/residue.py
+++ b/prolif/residue.py
@@ -308,7 +308,8 @@ def ignore_self_interactions(
     Returns
     -------
     bool
-        ``True`` if the residues are the same, ``False`` otherwise.
+        ``True`` if the residues are the same and should be skipped, ``False``
+        otherwise.
 
 
     .. versionadded:: 2.2.0

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -194,11 +194,10 @@ class TestFingerprint:
         assert "Hydrophobic" in int_data
 
     def test_generate_ignore(
-        self, fp_simple: Fingerprint, ligand_mol: "Molecule", protein_mol: "Molecule"
+        self, ligand_mol: "Molecule", protein_mol: "Molecule"
     ) -> None:
-        ifp = fp_simple.generate(
-            ligand_mol, protein_mol, ignore=lambda _res1, _res2: True, metadata=True
-        )
+        fp = Fingerprint(["Hydrophobic"], ignore=lambda _res1, _res2: True)
+        ifp = fp.generate(ligand_mol, protein_mol, metadata=True)
         assert not ifp
 
     @pytest.mark.parametrize(
@@ -260,38 +259,36 @@ class TestFingerprint:
     @pytest.mark.parametrize("n_jobs", [None, 1])
     def test_run_ignore(
         self,
-        fp_simple: Fingerprint,
         u: mda.Universe,
         ligand_ag: "AtomGroup",
         protein_ag: "AtomGroup",
         n_jobs: int | None,
     ) -> None:
-        fp_simple.run(
+        fp_ignore = Fingerprint(["Hydrophobic"], ignore=lambda _res1, _res2: True)
+        fp_ignore.run(
             u.trajectory[0],
             ligand_ag,
             protein_ag,
-            ignore=lambda _res1, _res2: True,
             progress=False,
             n_jobs=n_jobs,
         )
-        assert fp_simple.ifp == {0: {}}
+        assert fp_ignore.ifp == {0: {}}
 
     @pytest.mark.parametrize("n_jobs", [None, 1])
     def test_run_from_iterable_ignore(
         self,
-        fp_simple: Fingerprint,
         ligand_mol: "Molecule",
         protein_mol: "Molecule",
         n_jobs: int | None,
     ) -> None:
-        fp_simple.run_from_iterable(
+        fp_ignore = Fingerprint(["Hydrophobic"], ignore=lambda _res1, _res2: True)
+        fp_ignore.run_from_iterable(
             [ligand_mol],
             protein_mol,
-            ignore=lambda _res1, _res2: True,
             progress=False,
             n_jobs=n_jobs,
         )
-        assert fp_simple.ifp == {0: {}}
+        assert fp_ignore.ifp == {0: {}}
 
     def test_to_df(
         self,

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -193,6 +193,14 @@ class TestFingerprint:
         int_data = ifp[key]
         assert "Hydrophobic" in int_data
 
+    def test_generate_ignore(
+        self, fp_simple: Fingerprint, ligand_mol: "Molecule", protein_mol: "Molecule"
+    ) -> None:
+        ifp = fp_simple.generate(
+            ligand_mol, protein_mol, ignore=lambda _res1, _res2: True, metadata=True
+        )
+        assert not ifp
+
     @pytest.mark.parametrize(
         "trajectory_slice",
         [
@@ -248,6 +256,42 @@ class TestFingerprint:
         lig_suppl = list(sdf_supplier(path))
         fp_simple.run_from_iterable(lig_suppl[:2], protein_mol, progress=False)
         assert len(fp_simple.ifp) == 2
+
+    @pytest.mark.parametrize("n_jobs", [None, 1])
+    def test_run_ignore(
+        self,
+        fp_simple: Fingerprint,
+        u: mda.Universe,
+        ligand_ag: "AtomGroup",
+        protein_ag: "AtomGroup",
+        n_jobs: int | None,
+    ) -> None:
+        fp_simple.run(
+            u.trajectory[0],
+            ligand_ag,
+            protein_ag,
+            ignore=lambda _res1, _res2: True,
+            progress=False,
+            n_jobs=n_jobs,
+        )
+        assert fp_simple.ifp == {0: {}}
+
+    @pytest.mark.parametrize("n_jobs", [None, 1])
+    def test_run_from_iterable_ignore(
+        self,
+        fp_simple: Fingerprint,
+        ligand_mol: "Molecule",
+        protein_mol: "Molecule",
+        n_jobs: int | None,
+    ) -> None:
+        fp_simple.run_from_iterable(
+            [ligand_mol],
+            protein_mol,
+            ignore=lambda _res1, _res2: True,
+            progress=False,
+            n_jobs=n_jobs,
+        )
+        assert fp_simple.ifp == {0: {}}
 
     def test_to_df(
         self,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -254,7 +254,7 @@ class TestMoleculeStandardizer:
 
         with pytest.raises(
             ValueError,
-            match="Could not apply template for residue ALA1.A: test",
+            match=r"Could not apply template for residue ALA1.A: test",
         ):
             standardizer(Chem.MolFromSequence("AA"))
 


### PR DESCRIPTION
Fixes #305 

Adds an `ignore` parameter to the run methods to bypass specific residue pairs (defaults to `lambda res1.resid == res2.resid`).
Mostly useful when calculating a residue interaction network.

TODO:
- [x] update changelog