### PR TITLE
Align  __contains__ with __getitem__ for IFP class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unrealised]
+## [Unreleased]
 
 ### Added
+
+- Support for richer `in` checks on `IFP` object.
 
 ### Fixed
 

--- a/prolif/ifp.py
+++ b/prolif/ifp.py
@@ -5,7 +5,7 @@ Storing interactions --- :mod:`prolif.ifp`
 
 from collections import UserDict
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, NamedTuple, Union, overload
+from typing import TYPE_CHECKING, Any, NamedTuple, Union, overload
 
 from prolif.residue import ResidueId
 
@@ -92,6 +92,13 @@ class IFP(UserDict[tuple[ResidueId, ResidueId], "IFPData"]):
             "either ResidueId or residue string. If you need to filter the IFP, a "
             "single ResidueId or residue string can also be used.",
         )
+
+    def __contains__(self, key: Any) -> bool:
+        try:
+            self[key]
+            return True
+        except KeyError:
+            return False
 
     def interactions(self) -> Iterator[InteractionData]:
         """Yields all interactions data as an :class:`InteractionData` namedtuple.

--- a/tests/test_ifp.py
+++ b/tests/test_ifp.py
@@ -51,18 +51,17 @@ def test_interaction_data_iteration(ifp: IFP) -> None:
 
 
 @pytest.mark.parametrize(
-    "key",
+    ("key", "expected"),
     [
-        ("LIG1.G", "VAL201.A"),
-        (ResidueId.from_string("LIG1.G"), ResidueId.from_string("VAL201.A")),
-        "VAL201.A",
-        ResidueId.from_string("VAL201.A"),
+        (("LIG1.G", "VAL201.A"), True),
+        ((ResidueId.from_string("LIG1.G"), ResidueId.from_string("VAL201.A")), True),
+        ("VAL201.A", True),
+        (ResidueId.from_string("VAL201.A"), True),
+        (0, False),
     ],
 )
-def test_contains(
-    ifp: IFP, key: tuple[ResidueId, ResidueId] | tuple[str, str] | ResidueId | str
-) -> None:
-    assert key in ifp
+def test_contains(ifp: IFP, key: Any, expected: bool) -> None:
+    assert (key in ifp) is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ifp.py
+++ b/tests/test_ifp.py
@@ -48,3 +48,18 @@ def test_interaction_data_iteration(ifp: IFP) -> None:
     assert "distance" in data.metadata
     for data in ifp.interactions():
         assert isinstance(data, InteractionData)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("LIG1.G", "VAL201.A"),
+        (ResidueId.from_string("LIG1.G"), ResidueId.from_string("VAL201.A")),
+        "VAL201.A",
+        ResidueId.from_string("VAL201.A"),
+    ],
+)
+def test_contains(
+    ifp: IFP, key: tuple[ResidueId, ResidueId] | tuple[str, str] | ResidueId | str
+) -> None:
+    assert key in ifp

--- a/tests/test_ifp.py
+++ b/tests/test_ifp.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -63,3 +63,17 @@ def test_contains(
     ifp: IFP, key: tuple[ResidueId, ResidueId] | tuple[str, str] | ResidueId | str
 ) -> None:
     assert key in ifp
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("LIG1.G", "VAL201.A"),
+        (ResidueId.from_string("LIG1.G"), ResidueId.from_string("VAL201.A")),
+        "VAL201.A",
+        ResidueId.from_string("VAL201.A"),
+    ],
+)
+def test_get(ifp: IFP, key: Any) -> None:
+    sentinel = object()
+    assert ifp.get(key, sentinel) is not sentinel


### PR DESCRIPTION
The following was failing unexpectedly despite the same key working for indexing:
```python
# works
fp.ifp[0]["LIG1.G", "ALA1.A"]

# doesn't work
("LIG1.G", "ALA1.A") in fp.ifp[0]
```